### PR TITLE
fix: make PR template field validation tolerate markdown code spans

### DIFF
--- a/scripts/validate_pr_submission.py
+++ b/scripts/validate_pr_submission.py
@@ -42,12 +42,23 @@ def parse_template_fields(body: str) -> Dict[str, str]:
         if not line.startswith("- ") or ":" not in line:
             continue
         key, value = line[2:].split(":", 1)
-        fields[key.strip()] = value.strip()
+        fields[key.strip()] = normalize_template_value(value)
     return fields
 
 
 def normalize(value: str) -> str:
     return value.strip().lower()
+
+
+def normalize_template_value(value: str) -> str:
+    normalized = value.strip()
+
+    # Accept common Markdown inline-code formatting in PR templates,
+    # e.g. `dev` or ``skills/my-skill``.
+    while len(normalized) >= 2 and normalized[0] == normalized[-1] == "`":
+        normalized = normalized[1:-1].strip()
+
+    return normalized
 
 
 def load_pr_context() -> Tuple[str, str, str]:

--- a/tests/test_validate_pr_submission.py
+++ b/tests/test_validate_pr_submission.py
@@ -1,0 +1,62 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.validate_pr_submission import (
+    parse_template_fields,
+    validate_contributor_pr,
+)
+
+
+class ValidatePrSubmissionTests(unittest.TestCase):
+    def test_parse_template_fields_strips_markdown_code_ticks(self) -> None:
+        body = """
+- 目标分支: `dev`
+- 源分支: `feat/agent-boundary-design`
+- Skill 路径: `skills/agent-boundary-design`
+"""
+
+        fields = parse_template_fields(body)
+
+        self.assertEqual(fields["目标分支"], "dev")
+        self.assertEqual(fields["源分支"], "feat/agent-boundary-design")
+        self.assertEqual(fields["Skill 路径"], "skills/agent-boundary-design")
+
+    def test_validate_contributor_pr_accepts_inline_code_template_values(self) -> None:
+        body = """
+- PR 类型: `业务同学提交到 dev`
+- 目标分支: `dev`
+- 源分支: `feat/agent-boundary-design`
+- Skill 名称: `agent-boundary-design`
+- Skill 路径: `skills/agent-boundary-design`
+- 业务场景: `用于在业务 Agent 设计阶段明确职责边界`
+- 分支名: `feat/agent-boundary-design`
+- 本次是否由 Agent 辅助提交: `是`
+"""
+        errors = []
+        original_cwd = Path.cwd()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            skill_dir = temp_path / "skills" / "agent-boundary-design"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text("# test\n", encoding="utf-8")
+            os.chdir(temp_path)
+
+            try:
+                validate_contributor_pr(
+                    body=body,
+                    branch="feat/agent-boundary-design",
+                    base_ref="dev",
+                    files=["skills/agent-boundary-design/SKILL.md"],
+                    errors=errors,
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更信息

- PR 类型: 仓库维护提交到 dev
- 目标分支: dev
- 源分支: fix/pr-template-markdown-normalization
- 分支名: fix/pr-template-markdown-normalization

## 本次变更内容

- 修复 `skills-pr-guard` 对 PR 模板字段的解析逻辑
- 兼容业务同学在模板字段中使用 Markdown 行内代码写法，例如 `` `dev` ``、`` `feat/agent-boundary-design` ``、`` `skills/agent-boundary-design` ``
- 补充针对字段解析和业务 PR 校验的测试，避免后续回归

## 验证方式

- `python3 -m unittest tests.test_validate_pr_submission`
- `python3 scripts/validate_pr_submission.py local --base-ref origin/dev`

## 补充说明

- 本次修复不会放松实际规则，只是去掉字段值外层常见的反引号包裹
- 目的是减少 PR 模板按 Markdown 常规写法填写时的误判
