### PR TITLE
fix: support fork business skill PR guard without manual approval

### DIFF
--- a/.github/workflows/skills-pr-guard.yml
+++ b/.github/workflows/skills-pr-guard.yml
@@ -7,20 +7,55 @@ on:
       - edited
       - reopened
       - synchronize
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   skills-pr-guard:
     name: skills-pr-guard
     runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository)
 
     steps:
-      - name: Checkout repository
+      - name: Resolve guard mode
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            echo "GUARD_MODE=pr-target" >> "$GITHUB_ENV"
+          else
+            echo "GUARD_MODE=pr" >> "$GITHUB_ENV"
+          fi
+
+      - name: Checkout trusted base branch for fork PR
+        if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+
+      - name: Checkout PR head for same-repo PR
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Fetch base branch
+      - name: Fetch base branch for same-repo PR
+        if: github.event_name == 'pull_request'
         run: git fetch origin "${{ github.base_ref }}" --depth=1
 
       - name: Validate PR template and skills diff
-        run: python3 scripts/validate_pr_submission.py pr
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 scripts/validate_pr_submission.py "$GUARD_MODE"

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ bash scripts/install-hooks.sh
 - 仓库维护 PR 是否混入业务 Skill 目录改动
 - 是否在公开仓库中提交了个人身份信息
 
+对于来自 Fork 的业务 Skill PR，Guard 会走一条只读的安全校验路径，自动读取 PR 元数据和改动文件列表完成校验，不要求仓库维护者先手动批准 workflow 再开始执行。
+
 对于业务 Skill PR，维护者还可以手动触发 `Skill PR AI Eval`，生成一条 AI 辅助审阅评论。
 
 如果不符合规范，push 前的本地 hook 会直接报错，PR 上的 GitHub Action 也会失败并阻止合入。

--- a/scripts/validate_pr_submission.py
+++ b/scripts/validate_pr_submission.py
@@ -165,6 +165,27 @@ def split_repo_full_name(full_name: str) -> Tuple[str, str]:
     return owner, repo
 
 
+def skill_file_exists_after_pr(
+    skill_md_path: str,
+    pr_files: List[Dict[str, Any]],
+    *,
+    base_exists: bool,
+    head_exists: bool,
+) -> bool:
+    for item in pr_files:
+        filename = item.get("filename")
+        previous_filename = item.get("previous_filename")
+        status = item.get("status")
+
+        if filename == skill_md_path:
+            return status != "removed"
+
+        if previous_filename == skill_md_path:
+            return False
+
+    return base_exists or head_exists
+
+
 def touches_business_skill(files: List[str]) -> bool:
     return any(
         path.startswith(f"{SKILLS_ROOT}/")
@@ -511,24 +532,28 @@ def run_pr_target() -> int:
         )
         if changed_skill_dir:
             skill_md_path = f"{SKILLS_ROOT}/{changed_skill_dir}/SKILL.md"
-            changed_skill_md = any(
-                item.get("filename") == skill_md_path and item.get("status") != "removed"
-                for item in pr_files
-            )
-            if changed_skill_md:
-                skill_md_exists = True
-            else:
-                try:
-                    head_owner, head_repo = split_repo_full_name(head_repo_full_name)
-                    skill_md_exists = path_exists_in_repo(
-                        head_owner,
-                        head_repo,
-                        skill_md_path,
-                        head_sha,
-                        token,
-                    )
-                except RuntimeError as exc:
-                    errors.append(str(exc))
+            base_skill_md_exists = Path(skill_md_path).exists()
+            head_skill_md_exists = False
+
+            try:
+                head_owner, head_repo = split_repo_full_name(head_repo_full_name)
+                head_skill_md_exists = path_exists_in_repo(
+                    head_owner,
+                    head_repo,
+                    skill_md_path,
+                    head_sha,
+                    token,
+                )
+            except RuntimeError as exc:
+                errors.append(str(exc))
+
+            if not errors:
+                skill_md_exists = skill_file_exists_after_pr(
+                    skill_md_path,
+                    pr_files,
+                    base_exists=base_skill_md_exists,
+                    head_exists=head_skill_md_exists,
+                )
 
     if not errors:
         validate_contributor_pr(

--- a/scripts/validate_pr_submission.py
+++ b/scripts/validate_pr_submission.py
@@ -6,8 +6,11 @@ import os
 import re
 import subprocess
 import sys
+from urllib import error as urllib_error
+from urllib import parse as urllib_parse
+from urllib import request as urllib_request
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 
 SKILLS_ROOT = "skills"
@@ -33,6 +36,16 @@ def git(*args: str) -> str:
 def changed_files(base_ref: str) -> List[str]:
     diff = git("diff", "--name-only", f"{base_ref}...HEAD")
     return [line for line in diff.splitlines() if line.strip()]
+
+
+def load_pr_payload() -> Dict[str, Any]:
+    raw_event = (os.getenv("GITHUB_EVENT_PATH") or "").strip()
+    raw_event_path = Path(raw_event) if raw_event else None
+
+    if raw_event_path and raw_event_path.exists():
+        return json.loads(raw_event_path.read_text())
+
+    return {}
 
 
 def parse_template_fields(body: str) -> Dict[str, str]:
@@ -61,16 +74,12 @@ def normalize_template_value(value: str) -> str:
     return normalized
 
 
-def load_pr_context() -> Tuple[str, str, str]:
+def load_pr_context(payload: Optional[Dict[str, Any]] = None) -> Tuple[str, str, str]:
     body = ""
     head_ref = ""
     base_ref = ""
 
-    raw_event = (os.getenv("GITHUB_EVENT_PATH") or "").strip()
-    raw_event_path = Path(raw_event) if raw_event else None
-
-    if raw_event_path and raw_event_path.exists():
-        payload = json.loads(raw_event_path.read_text())
+    if payload:
         pull_request = payload.get("pull_request", {})
         body = pull_request.get("body") or ""
         head_ref = pull_request.get("head", {}).get("ref") or ""
@@ -82,6 +91,78 @@ def load_pr_context() -> Tuple[str, str, str]:
         base_ref = (os.getenv("GITHUB_BASE_REF") or "").strip()
 
     return body, head_ref, base_ref
+
+
+def github_api_get_json(url: str, token: str) -> Any:
+    request = urllib_request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "skills-pr-guard",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+
+    try:
+        with urllib_request.urlopen(request) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib_error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API request failed ({exc.code}) for {url}: {body}") from exc
+
+
+def list_pr_files(owner: str, repo: str, pull_number: int, token: str) -> List[Dict[str, Any]]:
+    files: List[Dict[str, Any]] = []
+    page = 1
+
+    while True:
+        url = (
+            f"https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}/files"
+            f"?per_page=100&page={page}"
+        )
+        page_items = github_api_get_json(url, token)
+        if not isinstance(page_items, list):
+            raise RuntimeError("Unexpected GitHub API response while listing pull request files.")
+
+        files.extend(page_items)
+        if len(page_items) < 100:
+            break
+        page += 1
+
+    return files
+
+
+def path_exists_in_repo(owner: str, repo: str, path: str, ref: str, token: str) -> bool:
+    encoded_path = urllib_parse.quote(path, safe="/")
+    encoded_ref = urllib_parse.quote(ref, safe="")
+    url = f"https://api.github.com/repos/{owner}/{repo}/contents/{encoded_path}?ref={encoded_ref}"
+
+    request = urllib_request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "skills-pr-guard",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+
+    try:
+        with urllib_request.urlopen(request):
+            return True
+    except urllib_error.HTTPError as exc:
+        exc.read()
+        if exc.code == 404:
+            return False
+        raise RuntimeError(f"GitHub API request failed ({exc.code}) for {url}") from exc
+
+
+def split_repo_full_name(full_name: str) -> Tuple[str, str]:
+    if "/" not in full_name:
+        raise RuntimeError(f"Invalid repository full name: {full_name}")
+    owner, repo = full_name.split("/", 1)
+    return owner, repo
 
 
 def touches_business_skill(files: List[str]) -> bool:
@@ -112,7 +193,10 @@ def validate_maintenance_branch(branch: str, errors: List[str]) -> None:
 
 
 def validate_changed_skill_files(
-    files: List[str], expected_skill_slug: Optional[str], errors: List[str]
+    files: List[str],
+    expected_skill_slug: Optional[str],
+    errors: List[str],
+    skill_md_exists: Optional[bool] = None,
 ) -> Optional[str]:
     if not files:
         errors.append("没有检测到任何改动。")
@@ -171,7 +255,8 @@ def validate_changed_skill_files(
         )
 
     skill_md = Path(SKILLS_ROOT) / skill_dir / "SKILL.md"
-    if not skill_md.exists():
+    has_skill_md = skill_md_exists if skill_md_exists is not None else skill_md.exists()
+    if not has_skill_md:
         errors.append(
             f"缺少 `{skill_md.as_posix()}`。每个 Skill 目录都必须包含 `SKILL.md`。"
         )
@@ -186,13 +271,20 @@ def require_fields(fields: Dict[str, str], names: List[str], errors: List[str]) 
 
 
 def validate_contributor_pr(
-    body: str, branch: str, base_ref: str, files: List[str], errors: List[str]
+    body: str,
+    branch: str,
+    base_ref: str,
+    files: List[str],
+    errors: List[str],
+    skill_md_exists: Optional[bool] = None,
 ) -> None:
     if base_ref != "dev":
         errors.append("业务同学的 Skill PR 必须提交到 `dev`，不能直接提到 `main`。")
 
     expected_skill_slug = validate_feature_branch(branch, errors)
-    changed_skill_dir = validate_changed_skill_files(files, expected_skill_slug, errors)
+    changed_skill_dir = validate_changed_skill_files(
+        files, expected_skill_slug, errors, skill_md_exists=skill_md_exists
+    )
 
     fields = parse_template_fields(body)
     require_fields(
@@ -322,7 +414,8 @@ def run_local(base_ref: str) -> int:
 
 
 def run_pr() -> int:
-    body, branch, base_ref = load_pr_context()
+    payload = load_pr_payload()
+    body, branch, base_ref = load_pr_context(payload)
 
     try:
         git("fetch", "origin", base_ref, "--depth=1")
@@ -352,6 +445,111 @@ def run_pr() -> int:
     return 0
 
 
+def run_pr_target() -> int:
+    payload = load_pr_payload()
+    body, branch, base_ref = load_pr_context(payload)
+    pull_request = payload.get("pull_request", {})
+    repository = payload.get("repository", {})
+    errors: List[str] = []
+    head_repo = pull_request.get("head", {}).get("repo") or {}
+
+    owner = repository.get("owner", {}).get("login") or ""
+    repo = repository.get("name") or ""
+    repo_full_name = repository.get("full_name") or ""
+    pull_number = pull_request.get("number") or payload.get("number")
+    head_repo_full_name = head_repo.get("full_name") or ""
+    head_sha = pull_request.get("head", {}).get("sha") or ""
+    token = (os.getenv("GITHUB_TOKEN") or "").strip()
+
+    if not owner or not repo or not repo_full_name or not pull_number:
+        errors.append("缺少 Pull Request 仓库上下文，无法执行 Fork PR 校验。")
+
+    if not head_repo_full_name or not head_sha:
+        errors.append("缺少 Fork PR 的 head 仓库或提交信息，无法执行校验。")
+
+    if not token:
+        errors.append("缺少 `GITHUB_TOKEN`，无法通过 GitHub API 读取 Fork PR 变更。")
+
+    if errors:
+        print("PR 校验失败：")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    is_fork = head_repo_full_name != repo_full_name
+    if not is_fork:
+        print("PR 校验失败：")
+        print("- `pr-target` 模式只应用于来自 Fork 的业务 Skill PR。")
+        return 1
+
+    try:
+        pr_files = list_pr_files(owner, repo, int(pull_number), token)
+    except RuntimeError as exc:
+        print("PR 校验失败：")
+        print(f"- {exc}")
+        return 1
+
+    files = [item.get("filename", "") for item in pr_files if item.get("filename")]
+
+    if base_ref != "dev":
+        errors.append("来自 Fork 的 PR 只支持业务 Skill 提交到 `dev`。")
+
+    if not touches_business_skill(files):
+        errors.append(
+            "来自 Fork 的 PR 仅支持业务 Skill 提交；仓库维护或发布 PR 请在主仓库分支中发起。"
+        )
+
+    skill_md_exists: Optional[bool] = None
+    if not errors:
+        preflight_errors: List[str] = []
+        expected_skill_slug = validate_feature_branch(branch, preflight_errors)
+        changed_skill_dir = validate_changed_skill_files(
+            files,
+            expected_skill_slug,
+            preflight_errors,
+            skill_md_exists=True,
+        )
+        if changed_skill_dir:
+            skill_md_path = f"{SKILLS_ROOT}/{changed_skill_dir}/SKILL.md"
+            changed_skill_md = any(
+                item.get("filename") == skill_md_path and item.get("status") != "removed"
+                for item in pr_files
+            )
+            if changed_skill_md:
+                skill_md_exists = True
+            else:
+                try:
+                    head_owner, head_repo = split_repo_full_name(head_repo_full_name)
+                    skill_md_exists = path_exists_in_repo(
+                        head_owner,
+                        head_repo,
+                        skill_md_path,
+                        head_sha,
+                        token,
+                    )
+                except RuntimeError as exc:
+                    errors.append(str(exc))
+
+    if not errors:
+        validate_contributor_pr(
+            body,
+            branch,
+            base_ref,
+            files,
+            errors,
+            skill_md_exists=skill_md_exists,
+        )
+
+    if errors:
+        print("PR 校验失败：")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("PR 校验通过。")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="mode", required=True)
@@ -360,12 +558,15 @@ def main() -> int:
     local_parser.add_argument("--base-ref", default="origin/dev")
 
     subparsers.add_parser("pr")
+    subparsers.add_parser("pr-target")
 
     args = parser.parse_args()
 
     try:
         if args.mode == "local":
             return run_local(args.base_ref)
+        if args.mode == "pr-target":
+            return run_pr_target()
         return run_pr()
     except subprocess.CalledProcessError as exc:
         sys.stderr.write(exc.stderr)

--- a/tests/test_validate_pr_submission.py
+++ b/tests/test_validate_pr_submission.py
@@ -1,15 +1,74 @@
+import io
+import json
 import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
+from scripts import validate_pr_submission
 from scripts.validate_pr_submission import (
     parse_template_fields,
+    run_pr_target,
     validate_contributor_pr,
 )
 
 
 class ValidatePrSubmissionTests(unittest.TestCase):
+    def make_fork_pr_payload(self, *, body: str, head_ref: str, base_ref: str = "dev") -> dict:
+        return {
+            "number": 12,
+            "repository": {
+                "name": "AgenticAISkills",
+                "full_name": "AgenticAIPlan/AgenticAISkills",
+                "owner": {"login": "AgenticAIPlan"},
+            },
+            "pull_request": {
+                "number": 12,
+                "body": body,
+                "head": {
+                    "ref": head_ref,
+                    "sha": "abc123",
+                    "repo": {"full_name": "student/AgenticAISkills"},
+                },
+                "base": {"ref": base_ref},
+            },
+        }
+
+    def run_pr_target_with_payload(
+        self,
+        payload: dict,
+        pr_files: list[dict],
+        *,
+        skill_md_exists: bool = False,
+    ) -> int:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            event_path = Path(temp_dir) / "event.json"
+            event_path.write_text(
+                json.dumps(payload, ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_EVENT_PATH": str(event_path),
+                    "GITHUB_TOKEN": "test-token",
+                },
+                clear=False,
+            ):
+                with patch.object(
+                    validate_pr_submission,
+                    "list_pr_files",
+                    return_value=pr_files,
+                ), patch.object(
+                    validate_pr_submission,
+                    "path_exists_in_repo",
+                    return_value=skill_md_exists,
+                ):
+                    with patch("sys.stdout", new=io.StringIO()):
+                        return run_pr_target()
+
     def test_parse_template_fields_strips_markdown_code_ticks(self) -> None:
         body = """
 - 目标分支: `dev`
@@ -56,6 +115,104 @@ class ValidatePrSubmissionTests(unittest.TestCase):
                 os.chdir(original_cwd)
 
         self.assertEqual(errors, [])
+
+    def test_run_pr_target_accepts_valid_fork_business_skill_pr(self) -> None:
+        payload = self.make_fork_pr_payload(
+            body="""
+- PR 类型: `业务同学提交到 dev`
+- 目标分支: `dev`
+- 源分支: `feat/credit-review-copilot`
+- Skill 名称: `credit-review-copilot`
+- Skill 路径: `skills/credit-review-copilot`
+- 业务场景: `授信审核辅助`
+- 分支名: `feat/credit-review-copilot`
+- 本次是否由 Agent 辅助提交: `是`
+""",
+            head_ref="feat/credit-review-copilot",
+        )
+
+        exit_code = self.run_pr_target_with_payload(
+            payload,
+            [
+                {
+                    "filename": "skills/credit-review-copilot/SKILL.md",
+                    "status": "added",
+                }
+            ],
+        )
+
+        self.assertEqual(exit_code, 0)
+
+    def test_run_pr_target_accepts_existing_skill_without_skill_md_change(self) -> None:
+        payload = self.make_fork_pr_payload(
+            body="""
+- PR 类型: `业务同学提交到 dev`
+- 目标分支: `dev`
+- 源分支: `update/credit-review-copilot`
+- Skill 名称: `credit-review-copilot`
+- Skill 路径: `skills/credit-review-copilot`
+- 业务场景: `补充授信审核辅助参考资料`
+- 分支名: `update/credit-review-copilot`
+- 本次是否由 Agent 辅助提交: `否`
+""",
+            head_ref="update/credit-review-copilot",
+        )
+
+        exit_code = self.run_pr_target_with_payload(
+            payload,
+            [
+                {
+                    "filename": "skills/credit-review-copilot/references/README.md",
+                    "status": "modified",
+                }
+            ],
+            skill_md_exists=True,
+        )
+
+        self.assertEqual(exit_code, 0)
+
+    def test_run_pr_target_rejects_fork_maintenance_pr(self) -> None:
+        payload = self.make_fork_pr_payload(
+            body="""
+- PR 类型: `仓库维护提交到 dev`
+- 目标分支: `dev`
+- 源分支: `docs/update-readme`
+- 分支名: `docs/update-readme`
+""",
+            head_ref="docs/update-readme",
+        )
+
+        exit_code = self.run_pr_target_with_payload(
+            payload,
+            [{"filename": "README.md", "status": "modified"}],
+        )
+
+        self.assertEqual(exit_code, 1)
+
+    def test_run_pr_target_rejects_skill_pr_with_non_skill_files(self) -> None:
+        payload = self.make_fork_pr_payload(
+            body="""
+- PR 类型: `业务同学提交到 dev`
+- 目标分支: `dev`
+- 源分支: `feat/bad-skill`
+- Skill 名称: `bad-skill`
+- Skill 路径: `skills/bad-skill`
+- 业务场景: `测试非法改动`
+- 分支名: `feat/bad-skill`
+- 本次是否由 Agent 辅助提交: `否`
+""",
+            head_ref="feat/bad-skill",
+        )
+
+        exit_code = self.run_pr_target_with_payload(
+            payload,
+            [
+                {"filename": "skills/bad-skill/SKILL.md", "status": "added"},
+                {"filename": "README.md", "status": "modified"},
+            ],
+        )
+
+        self.assertEqual(exit_code, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_pr_submission.py
+++ b/tests/test_validate_pr_submission.py
@@ -10,6 +10,7 @@ from scripts import validate_pr_submission
 from scripts.validate_pr_submission import (
     parse_template_fields,
     run_pr_target,
+    skill_file_exists_after_pr,
     validate_contributor_pr,
 )
 
@@ -40,7 +41,8 @@ class ValidatePrSubmissionTests(unittest.TestCase):
         payload: dict,
         pr_files: list[dict],
         *,
-        skill_md_exists: bool = False,
+        base_skill_md_exists: bool = False,
+        head_skill_md_exists: bool = False,
     ) -> int:
         with tempfile.TemporaryDirectory() as temp_dir:
             event_path = Path(temp_dir) / "event.json"
@@ -48,6 +50,12 @@ class ValidatePrSubmissionTests(unittest.TestCase):
                 json.dumps(payload, ensure_ascii=False),
                 encoding="utf-8",
             )
+            original_cwd = Path.cwd()
+
+            if base_skill_md_exists:
+                skill_dir = Path(temp_dir) / "skills" / payload["pull_request"]["head"]["ref"].split("/", 1)[1]
+                skill_dir.mkdir(parents=True, exist_ok=True)
+                (skill_dir / "SKILL.md").write_text("# base skill\n", encoding="utf-8")
 
             with patch.dict(
                 os.environ,
@@ -64,10 +72,14 @@ class ValidatePrSubmissionTests(unittest.TestCase):
                 ), patch.object(
                     validate_pr_submission,
                     "path_exists_in_repo",
-                    return_value=skill_md_exists,
+                    return_value=head_skill_md_exists,
                 ):
-                    with patch("sys.stdout", new=io.StringIO()):
-                        return run_pr_target()
+                    os.chdir(temp_dir)
+                    try:
+                        with patch("sys.stdout", new=io.StringIO()):
+                            return run_pr_target()
+                    finally:
+                        os.chdir(original_cwd)
 
     def test_parse_template_fields_strips_markdown_code_ticks(self) -> None:
         body = """
@@ -166,7 +178,36 @@ class ValidatePrSubmissionTests(unittest.TestCase):
                     "status": "modified",
                 }
             ],
-            skill_md_exists=True,
+            head_skill_md_exists=True,
+        )
+
+        self.assertEqual(exit_code, 0)
+
+    def test_run_pr_target_accepts_stale_fork_when_base_already_has_skill_md(self) -> None:
+        payload = self.make_fork_pr_payload(
+            body="""
+- PR 类型: `业务同学提交到 dev`
+- 目标分支: `dev`
+- 源分支: `update/existing-skill`
+- Skill 名称: `existing-skill`
+- Skill 路径: `skills/existing-skill`
+- 业务场景: `补充已有 Skill 的参考资料`
+- 分支名: `update/existing-skill`
+- 本次是否由 Agent 辅助提交: `否`
+""",
+            head_ref="update/existing-skill",
+        )
+
+        exit_code = self.run_pr_target_with_payload(
+            payload,
+            [
+                {
+                    "filename": "skills/existing-skill/references/README.md",
+                    "status": "modified",
+                }
+            ],
+            base_skill_md_exists=True,
+            head_skill_md_exists=False,
         )
 
         self.assertEqual(exit_code, 0)
@@ -188,6 +229,21 @@ class ValidatePrSubmissionTests(unittest.TestCase):
         )
 
         self.assertEqual(exit_code, 1)
+
+    def test_skill_file_exists_after_pr_rejects_removed_skill_md_even_if_base_has_it(self) -> None:
+        self.assertFalse(
+            skill_file_exists_after_pr(
+                "skills/example-skill/SKILL.md",
+                [
+                    {
+                        "filename": "skills/example-skill/SKILL.md",
+                        "status": "removed",
+                    }
+                ],
+                base_exists=True,
+                head_exists=False,
+            )
+        )
 
     def test_run_pr_target_rejects_skill_pr_with_non_skill_files(self) -> None:
         payload = self.make_fork_pr_payload(


### PR DESCRIPTION
## 变更信息

- PR 类型: `仓库维护提交到 dev`
- 目标分支: `dev`
- 源分支: `fix/fork-skill-pr-guard`
- 分支名: `fix/fork-skill-pr-guard`

## 本次变更内容

- 调整 Skills PR Guard 的触发与分流逻辑
- 来自 Fork 的业务 Skill PR 改为走安全的只读校验路径，自动读取 PR 元数据与改动文件列表完成校验
- 同仓库维护 PR 与 `dev -> main` 发布 PR 继续沿用现有校验逻辑
- 补充 README 中对 Fork 业务 Skill PR 自动校验行为的说明

## 验证方式

- 运行 `python3 -m py_compile scripts/validate_pr_submission.py`
- 使用模拟 PR payload 校验以下场景：
  - Fork 业务 Skill PR 可通过
  - Fork 更新已有 Skill 且未改 `SKILL.md` 可通过
  - Fork 维护 PR 会被拒绝
  - Fork Skill PR 混入非 `skills/<skill-slug>/` 改动会被拒绝

## 补充说明

- 本次改动保持 Guard 主题不变，仍然只做 PR 模板与 Skill 改动规范校验
- Fork 路径不 checkout、不执行 PR 代码，workflow 权限收紧为只读
