### PR TITLE
feat: add editorial-tech-atlas skill

### DIFF
--- a/skills/editorial-tech-atlas/SKILL.md
+++ b/skills/editorial-tech-atlas/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: editorial-tech-atlas
+description: Design and build high-end editorial technology websites with a dark, modern, systems-explorer feel. Use this skill whenever the user wants a polished product site, interactive narrative page, architecture explainer, feature atlas, research-style microsite, proposal demo page, whitepaper-to-site conversion, long-scroll technology story, or any section-based web experience with premium typography, subdued dark surfaces, hover-reveal details, anchored deep-link sections, click-to-reveal panels, sticky section navigation, or an annotated systems-publication feel. Also trigger for phrasing like “很有科技感的网站”, “技术叙事页面”, “交互式白皮书”, “长滚动 microsite”, “可演示方案页”, or “像研究站点/系统地图一样”. Prefer this over generic frontend styling when the result should feel like a premium technical publication, not a standard marketing page or dashboard.
+license: CC BY-NC-SA 4.0
+---
+
+# Editorial Tech Atlas
+
+This skill is for building websites that feel like a premium interactive technology editorial: dark, restrained, information-dense, and carefully staged.
+
+The goal is not to clone any specific site. The goal is to reproduce the design grammar: strong narrative sections, premium typography, subtle motion, progressive disclosure, semantic color coding, and a modern research-lab mood.
+
+## What this skill should produce
+
+Use this skill when the deliverable should feel like:
+
+- a high-end interactive microsite
+- a technical story page with deep sections
+- a polished product or architecture explainer
+- a feature atlas with click-to-reveal detail
+- a dense but readable modern technology presentation site
+
+This is not a generic SaaS landing page.
+
+The output should feel authored, structural, and tactile.
+
+## Core design thesis
+
+Build the page like an annotated system map.
+
+That means:
+
+- content is organized into numbered narrative sections
+- the layout favors scanability first, then deeper interaction
+- hover gives hints, click reveals substance
+- color is semantic, not decorative
+- motion guides attention instead of showing off
+- typography carries hierarchy as much as layout does
+
+## Visual direction
+
+Default aesthetic:
+
+- near-black canvas
+- soft glass or matte panels
+- faint dividers and translucent layering
+- one warm metallic accent for primary emphasis
+- several muted category colors for semantic grouping
+- low-noise, editorial spacing with technical precision
+
+Avoid:
+
+- loud gradients everywhere
+- shiny cyberpunk neon overload
+- generic startup hero blocks
+- oversized pills and empty marketing fluff
+- random card grids with no narrative structure
+
+## Typography system
+
+Use a three-tier type system whenever possible:
+
+1. geometric or modern grotesk for headings and structural labels
+2. serif for explanatory body copy and more reflective paragraphs
+3. mono for commands, chips, counters, anchors, paths, metadata, and small labels
+
+Why this matters:
+
+- sans gives control and clarity
+- serif adds authority and editorial depth
+- mono signals system detail and technical specificity
+
+If web fonts are allowed, a strong default combination is:
+
+- heading: `Space Grotesk` or a similar sharp geometric grotesk
+- body: `Source Serif 4` or another readable editorial serif
+- mono: `JetBrains Mono` or a similarly crisp mono
+
+If the existing product already has a font system, adapt this logic rather than forcing these exact families.
+
+## Color system
+
+Define tokens first. Always create named variables.
+
+Recommended token groups:
+
+- `--bg`
+- `--bg-elevated`
+- `--surface`
+- `--surface-strong`
+- `--border`
+- `--text`
+- `--text-muted`
+- `--accent`
+- `--accent-soft`
+- `--category-*`
+
+Preferred palette behavior:
+
+- background sits near black, charcoal, graphite, or warm-black
+- text is soft white, not pure white
+- borders stay low-contrast but consistent
+- accent is singular and memorable, often warm gold, brass, or muted amber
+- category colors are desaturated and earthy, not toy-like
+
+Good category colors:
+
+- slate blue
+- rust
+- moss green
+- pale teal
+- dusty lavender
+- warm gray
+
+These should help classify content, not turn the page into a rainbow.
+
+## Layout grammar
+
+The page should feel like one composed document.
+
+Use this macro structure:
+
+1. immersive hero
+2. section rail or section navigator
+3. repeated numbered sections
+4. one main interactive module per section
+5. restrained footer that remains in-system
+
+Each major section should usually contain:
+
+- small section number
+- thin divider or horizontal rule
+- strong title
+- brief subhead
+- one primary interactive region
+
+Keep widths controlled. Dense information reads better inside deliberate max widths than edge-to-edge layouts.
+
+Prefer:
+
+- `max-width` containers
+- asymmetric internal composition
+- generous vertical rhythm
+- clear separation between overview and detail areas
+
+Avoid:
+
+- dashboard-wide stretch layouts for editorial content
+- perfectly even card mosaics without focal hierarchy
+- stacking too many unrelated modules into one section
+
+## Interaction model
+
+Follow this rule:
+
+- hover previews
+- click commits
+- scroll advances narrative
+
+Good uses of hover:
+
+- reveal a label next to an icon or section index
+- raise brightness slightly on a tile
+- hint at a hidden affordance
+- surface a one-line explanation
+
+Good uses of click:
+
+- open detail panels
+- swap the active record in a grid
+- drill into architecture nodes
+- open modal or sheet content on mobile
+
+Avoid hover-only critical information. The important state change should always be available through click or focus.
+
+## Deep-linking and navigation
+
+This design language works best with in-page deep links.
+
+Implement:
+
+- stable section IDs
+- smooth scrolling between sections
+- active section highlighting via scroll position or intersection observers
+- desktop side rail and mobile sheet or compact navigator when appropriate
+
+The usual pattern is:
+
+- high-level navigation jumps to sections
+- internal interactive modules manage detail state locally
+- URL changes are reserved for meaningful sections, not every micro-interaction
+
+If the project benefits from fully shareable states, add query params or hash fragments for active module state. Otherwise keep detail state local and lightweight.
+
+## Progressive disclosure
+
+This is the heart of the style.
+
+Start with a readable surface, then reveal depth only when the user asks for it.
+
+Preferred pattern:
+
+- visible layer: concise labels, clear taxonomy, short descriptions
+- revealed layer: supporting notes, bullets, technical details, references, or examples
+
+Typical modules:
+
+- architecture explorer
+- tool or feature atlas
+- command or API explorer
+- hidden capabilities grid
+- timeline or release lattice
+- evidence cards or annotated reference blocks
+
+When a user clicks an item, render the detail in one of these ways:
+
+- adjacent sticky detail panel
+- expanded inline region below the selected grid
+- side sheet or bottom sheet on small screens
+- modal when the content is self-contained
+
+Do not reveal everything at once.
+
+## Motion rules
+
+Motion should be low-amplitude and purposeful.
+
+Use:
+
+- fade-ups on section entry
+- staggered reveals in hero and list regions
+- width expansion for navigation hints
+- opacity transitions for detail states
+- subtle scale or brightness shifts on active cards
+- slide-up bottom sheets on mobile
+
+Avoid:
+
+- bouncy micro-interactions everywhere
+- large parallax effects that distract from reading
+- dramatic 3D transforms with no semantic meaning
+
+If you animate, make sure the animation explains one of these:
+
+- this entered
+- this became active
+- this is expandable
+- this belongs to the current section
+
+## Surface styling
+
+Prefer surfaces that feel precise and physical:
+
+- soft translucent panels
+- matte dark blocks
+- thin borders
+- tiny highlight gradients
+- subtle internal shadows
+- faint background grids or line patterns
+
+Useful atmosphere elements:
+
+- animated grid background in the hero
+- noise or grain at very low opacity
+- soft radial glow behind focal regions
+- restrained backdrop blur on overlays
+
+Do not let atmosphere overpower legibility.
+
+## Responsive behavior
+
+Do not only resize. Re-compose.
+
+Desktop patterns:
+
+- fixed or sticky section rail
+- multi-column interactive layouts
+- adjacent detail panel next to a grid or map
+
+Mobile patterns:
+
+- bottom sheet section navigation
+- stacked overview then detail
+- reduced density in labels
+- larger tap targets and simplified hover affordances
+
+If a desktop pattern depends on hover, convert it into tap-select behavior on mobile.
+
+## Implementation workflow
+
+Follow this order.
+
+### 1. Define the narrative structure
+
+Break the page into 3-7 numbered sections.
+
+For each section, define:
+
+- section ID
+- section number
+- title
+- one-sentence thesis
+- primary interactive module
+- what detail is hidden by default
+
+### 2. Define tokens
+
+Before building modules, create the theme tokens for color, spacing, radius, shadow, blur, and typography.
+
+### 3. Build the shell
+
+Implement:
+
+- page background and atmosphere
+- hero
+- section wrappers
+- global nav or section rail
+- mobile navigation pattern
+
+### 4. Build one flagship module first
+
+Start with the section that best proves the visual system. Usually this is:
+
+- an architecture explorer
+- a categorized feature grid
+- a technical command atlas
+
+Only propagate the system once that section feels convincing.
+
+### 5. Add disclosure behavior
+
+Make the overview state elegant first. Then add selection, detail reveal, keyboard focus, and mobile sheet logic.
+
+### 6. Add motion last
+
+Do not use animation to rescue weak layout. The composition should work fully before motion.
+
+## Recommended component set
+
+This style often benefits from components like:
+
+- `HeroSection`
+- `SectionRail`
+- `SectionBlock`
+- `InfoPanel`
+- `ExplorerGrid`
+- `ExplorerCard`
+- `DetailPane`
+- `MobileSectionSheet`
+- `StatStrip`
+- `TaxonomyChip`
+- `AmbientGrid`
+
+Keep state ownership clean. Navigator state and selected-item state should not be mixed together unnecessarily.
+
+## Content writing guidance
+
+The copy should be concise, informed, and technical without reading like marketing sludge.
+
+Use:
+
+- short declarative section titles
+- one or two sentence subheads
+- restrained metadata labels
+- concise bullet detail panels
+
+Avoid:
+
+- hype-heavy slogans
+- long product-marketing paragraphs
+- vague claims with no content structure
+
+The right tone is closer to an annotated systems publication than a startup billboard.
+
+## Accessibility and robustness
+
+Always preserve:
+
+- keyboard access for all interactive tiles and nav items
+- visible focus states
+- sufficient contrast for body text and metadata
+- reduced-motion fallback
+- touch-friendly interaction for mobile
+
+If using server-rendered entry animations, avoid a blank pre-hydration state. Remove or neutralize hidden initial transforms when hydration is delayed.
+
+## Output expectations
+
+When this skill succeeds, the output should usually include:
+
+- a complete page or section system
+- reusable tokens and typography rules
+- at least one strong progressive-disclosure module
+- anchored sections with clear navigation
+- responsive behavior tuned for both desktop and mobile
+- restrained but premium motion
+
+## Reference files
+
+Read these references when useful:
+
+- `references/design-principles.md` for the full style anatomy
+- `references/interaction-patterns.md` for hover, click, detail, and deep-link behavior
+- `references/implementation-playbook.md` for practical coding structure
+
+## Final reminder
+
+Do not imitate branding, copy, or unique illustrations from any one reference site.
+
+Instead, capture the underlying design intelligence:
+
+- editorial hierarchy
+- dark precision
+- semantic color
+- progressive disclosure
+- interactive systems thinking
+
+That is what makes this style powerful.

--- a/skills/editorial-tech-atlas/references/design-principles.md
+++ b/skills/editorial-tech-atlas/references/design-principles.md
@@ -1,0 +1,120 @@
+# Design Principles
+
+Use this reference when you need to internalize the visual language before coding.
+
+## Style summary
+
+The target feeling is:
+
+- dark
+- modern
+- technical
+- premium
+- authored
+- information-rich
+
+This is not futuristic chaos and not minimal corporate SaaS.
+
+Think of it as a research journal, systems atlas, and polished product microsite meeting in the middle.
+
+## The five strongest signals
+
+### 1. Editorial section framing
+
+The page reads like a publication, not a feed.
+
+Common structure:
+
+- numeric section marker
+- divider line
+- section title
+- concise thesis text
+- one central interactive block
+
+This repetition gives the site rhythm and helps different modules feel like one authored system.
+
+### 2. Three-way typography contrast
+
+The style becomes much stronger when type roles are intentionally split:
+
+- grotesk or modern sans for structure and interface
+- serif for interpretation and explanation
+- mono for technical labeling and evidence
+
+This avoids the flatness that happens when one font tries to do everything.
+
+### 3. Muted semantic color
+
+The page should not depend on loud saturation.
+
+Use:
+
+- one memorable primary accent
+- several dusty category colors
+- strong consistency in where those colors are applied
+
+Colors should tell the user what category, state, or mode they are looking at.
+
+### 4. Progressive disclosure
+
+The overview must be elegant enough to scan in seconds.
+
+Detail should emerge only after intent.
+
+This keeps dense technical content from feeling exhausting.
+
+### 5. Precision surfaces
+
+Cards should feel engineered.
+
+Use:
+
+- thin borders
+- subtle translucency
+- disciplined radius scale
+- soft highlights
+- tiny shifts in brightness or opacity on interaction
+
+Avoid chunky consumer-app styling.
+
+## Mood board in words
+
+If you need to explain the visual tone in plain language:
+
+- midnight lab
+- atlas of systems
+- premium developer editorial
+- machine room, but curated
+- technical story with museum-grade labeling
+
+## Common failure modes
+
+Avoid these mistakes:
+
+- too much neon, which makes the result feel game-like
+- too much blur, which makes the structure feel mushy
+- too many panels, which destroys focal hierarchy
+- huge paragraphs inside cards, which kills scanning
+- purely decorative motion, which weakens the seriousness
+- one-font systems, which flatten the tone
+- generic startup CTA patterns, which break the editorial illusion
+
+## A strong default palette direction
+
+Use this as a starting point, then adapt:
+
+- background: warm black or graphite
+- elevated panel: charcoal with slight transparency
+- text: soft ivory or cool off-white
+- border: smoky gray with low contrast
+- accent: brass, amber, muted gold, or warm ochre
+- semantic set: moss, slate, rust, lavender, teal, stone
+
+## A strong default spacing direction
+
+- roomy section spacing
+- restrained internal padding
+- tighter metadata spacing
+- larger gaps between section framing and interactive modules
+
+Macro spacing should feel calm. Micro spacing should feel exact.

--- a/skills/editorial-tech-atlas/references/implementation-playbook.md
+++ b/skills/editorial-tech-atlas/references/implementation-playbook.md
@@ -1,0 +1,185 @@
+# Implementation Playbook
+
+Use this reference when turning the style into real code.
+
+## Recommended project shape
+
+For a React or similar frontend project, a clean structure is:
+
+```text
+src/
+  app/
+  components/
+    AmbientGrid.*
+    HeroSection.*
+    SectionRail.*
+    SectionBlock.*
+    ExplorerGrid.*
+    ExplorerCard.*
+    DetailPane.*
+    MobileSectionSheet.*
+  data/
+    sections.*
+    taxonomy.*
+  styles/
+    tokens.css
+    base.css
+    motion.css
+```
+
+The point is to keep:
+
+- data separate from presentation
+- tokens centralized
+- interaction primitives reusable
+
+## Build order
+
+### 1. Tokens first
+
+Implement:
+
+- color variables
+- type scale
+- spacing scale
+- radius scale
+- blur and shadow tokens
+- motion durations
+
+Do not hardcode ad hoc values throughout components.
+
+### 2. Shell second
+
+Build:
+
+- page background
+- hero
+- section wrappers
+- nav rail or section navigator
+- responsive max-width system
+
+### 3. One flagship module
+
+Get one interactive section right before multiplying patterns.
+
+Best starting options:
+
+- explorer grid with detail pane
+- architecture tree with selected state
+- categorized feature atlas
+
+### 4. Responsive redesign pass
+
+Do not wait until the end to check mobile.
+
+Specifically test:
+
+- section navigation
+- detail reveal pattern
+- dense card grids
+- sticky elements
+
+### 5. Motion and polish pass
+
+Add:
+
+- hero stagger
+- section entry transitions
+- subtle hover brightness
+- detail reveal transitions
+
+Then stop before it becomes too ornamental.
+
+## Practical coding rules
+
+### Use stable section data
+
+Represent sections as structured data:
+
+- `id`
+- `index`
+- `title`
+- `summary`
+- `component`
+
+This makes side rails, mobile navigators, and active states easier to keep in sync.
+
+### Keep module state local
+
+Examples:
+
+- active architecture node
+- selected feature card
+- current explorer tab
+
+Section navigation should stay global. Explorer selection should stay local unless shareability really matters.
+
+### Use semantic classes and tokens
+
+Favor classes like:
+
+- `.section-frame`
+- `.section-kicker`
+- `.explorer-card`
+- `.detail-pane`
+- `.taxonomy-chip`
+
+This makes later theming and polish much easier than one-off utility soup alone.
+
+### Animate opacity and transform, not layout chaos
+
+Good:
+
+- opacity
+- translateY
+- scale within tight bounds
+- width expansion for a nav label
+
+Use layout reflow sparingly and intentionally.
+
+### Design for pre-hydration safety
+
+If using SSR or partial hydration:
+
+- avoid hiding large content blocks with inline `opacity: 0` until JS runs
+- provide a readable static fallback
+- make the no-JS state respectable
+
+## Suggested CSS token starter
+
+```css
+:root {
+  --bg: #0d0d0d;
+  --bg-elevated: rgba(255, 255, 255, 0.03);
+  --surface: rgba(255, 255, 255, 0.05);
+  --surface-strong: rgba(255, 255, 255, 0.08);
+  --border: rgba(255, 255, 255, 0.12);
+  --text: rgba(245, 242, 235, 0.94);
+  --text-muted: rgba(245, 242, 235, 0.62);
+  --accent: #d4a853;
+  --category-slate: #7b9eb8;
+  --category-rust: #c17b5e;
+  --category-moss: #6ba368;
+  --category-teal: #9bbec7;
+  --category-lavender: #b8a9c9;
+  --category-stone: #8a8580;
+}
+```
+
+Treat this as a starting skeleton, not a fixed brand system.
+
+## Review checklist
+
+Before finishing, verify:
+
+- the page has a clear section narrative
+- one glance reveals hierarchy
+- hover never carries the full meaning alone
+- click states are obvious
+- the detail layer adds real substance
+- fonts are doing distinct jobs
+- the palette is restrained and semantic
+- mobile keeps the concept intact
+- motion improves focus rather than stealing it
+
+If the result feels like a normal startup landing page with darker colors, the system is not strong enough yet.

--- a/skills/editorial-tech-atlas/references/interaction-patterns.md
+++ b/skills/editorial-tech-atlas/references/interaction-patterns.md
@@ -1,0 +1,195 @@
+# Interaction Patterns
+
+Use this reference when building the page's behavior.
+
+## Interaction philosophy
+
+The site should reward curiosity without overwhelming the first pass.
+
+That means:
+
+- first glance gives structure
+- second glance gives taxonomy
+- click gives depth
+
+## Navigation patterns
+
+### Section rail
+
+Desktop navigation works well as a fixed or sticky rail.
+
+Good behavior:
+
+- compact by default
+- expands on hover or focus
+- keeps section indices visible at all times
+- highlights the active section while scrolling
+
+This gives the page a strong spatial memory.
+
+### Mobile section sheet
+
+On small screens, replace the rail with:
+
+- a floating button
+- a compact pill
+- a bottom sheet or slide-over list of sections
+
+The mobile pattern should preserve the section model, not collapse into a generic hamburger.
+
+## Card interaction patterns
+
+### Preview then commit
+
+Best default behavior:
+
+- hover or focus gives a short preview cue
+- click or tap selects the item
+- selected item updates a stable detail area
+
+This keeps the layout from jumping too much.
+
+### Detail pane
+
+For medium and large screens, show detail in:
+
+- an adjacent panel
+- a sticky side panel
+- an inline panel below the active grid
+
+For mobile, prefer:
+
+- accordion expansion
+- inline revealed block
+- bottom sheet
+
+### Taxonomy chips
+
+Small chips are useful for:
+
+- category labels
+- technical domains
+- command types
+- status or role markers
+
+Keep them small, crisp, and secondary. They should support the content, not dominate it.
+
+## Deep linking
+
+### Baseline
+
+Always provide stable IDs for major sections.
+
+Recommended:
+
+- `#overview`
+- `#architecture`
+- `#features`
+- `#commands`
+- `#hidden-capabilities`
+
+Use smooth scrolling and active-state updates.
+
+### Extended state
+
+Only encode local module state into the URL when sharing that state adds value.
+
+Good candidates:
+
+- selected architecture node
+- selected feature category
+- current tab in a multi-mode explorer
+
+Bad candidates:
+
+- transient hover state
+- tiny accordion toggles
+- every small UI detail
+
+## Hover patterns
+
+Keep hover subtle.
+
+Good hover treatments:
+
+- +5% to +12% brightness
+- slight border emphasis
+- faint label reveal
+- icon opacity increase
+- tiny upward translation only if it does not feel playful
+
+Avoid dramatic scaling and exaggerated glow.
+
+## Motion timings
+
+Strong defaults:
+
+- micro hover: `120ms-180ms`
+- panel reveal: `180ms-260ms`
+- section entry: `300ms-500ms`
+- sheet/modal entry: `220ms-320ms`
+
+Prefer `ease-out` or refined custom curves. Avoid springy motion unless the product already uses it.
+
+## Recommended modules
+
+### Architecture explorer
+
+Overview:
+
+- nodes or folders
+- relationship cues
+- short hover hint
+
+Reveal:
+
+- selected node detail
+- breadcrumb or path context
+- related items list
+
+### Feature or tool atlas
+
+Overview:
+
+- categorized cards
+- semantic colors
+- short labels
+
+Reveal:
+
+- detail pane with explanation, examples, related links, caveats
+
+### Command explorer
+
+Overview:
+
+- command families
+- one-line descriptions
+- mono labels
+
+Reveal:
+
+- syntax, use case, side effects, examples
+
+### Hidden features block
+
+Overview:
+
+- mystery or low-visibility features
+- restrained iconography
+
+Reveal:
+
+- why it matters
+- when to use it
+- example scenario
+
+## Accessibility notes
+
+Every hover interaction should also respond to:
+
+- focus
+- click
+- tap
+
+If an item looks interactive, it must be reachable by keyboard and communicate selection clearly.


### PR DESCRIPTION
## 变更信息

- PR 类型: `业务同学提交到 dev`
- 目标分支: `dev`
- 源分支: `feat/editorial-tech-atlas`
- 涉及 Skill 列表: （仅发布 PR 填写）
- Skill 名称: `editorial-tech-atlas`
- Skill 路径: `skills/editorial-tech-atlas`
- 业务场景: 将方案、白皮书和架构说明转换为可浏览、可演示、可按章节跳转的高质量技术叙事网页
- 分支名: `feat/editorial-tech-atlas`
- 本次是否由 Agent 辅助提交: 是

## 本次变更内容

- 新增 `skills/editorial-tech-atlas/SKILL.md`
- 新增该 Skill 所需的 `references/` 参考资料
- 仅保留仓库收录所需核心内容，不提交外围说明文件和 `evals/`
- 按仓库最新公开规则重新提交，移除旧规则中的个人身份信息字段

## 验证方式

- `python3 scripts/validate_pr_submission.py local --base-ref origin/dev`
- 确认本次改动仅涉及 `skills/editorial-tech-atlas/` 目录
- 确认提交文件为 `SKILL.md` 与 `references/` 资料

## 补充说明

- 本 PR 为旧规则下 PR #7 的重新提交版本
- 重新提交的原因是仓库规则已更新，公开仓库中不再允许在分支名、PR 描述或 Skill 内容里包含个人身份信息
- 参考资料包含设计原则、交互模式和实现手册，供 Skill 执行时引用

## Agent 提交备注

- 业务同学提交时，PR 目标分支必须是 `dev`
- 助教发布时，只允许从 `dev` 提 PR 到 `main`
- 公开仓库中不要填写任何个人身份信息