### PR TITLE
feat: add cloud-instance-ops skill

### DIFF
--- a/skills/cloud-instance-ops/SKILL.md
+++ b/skills/cloud-instance-ops/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: cloud-instance-ops
+description: Use for cloud instance access diagnosis and SSH/CLI-first operations in Codex, OpenClaw, or Claude Code when the task centers on Linux server access, password or key based SSH, file transfer, service or process checks, log inspection, AWS EC2 or Aliyun ECS inspection, or diagnosing blockers such as bastions, MFA, SSO, IP allowlists, approvals, and read-only permissions. Only extend into deployment, API serving, or cloud-side mutating actions when the user explicitly asks for them.
+---
+
+# Cloud Instance Ops
+
+## Overview
+Use this skill to manage cloud servers and instances like a careful human operator **within the current authorization boundary**. Prefer SSH and official cloud CLIs. Do **not** try to bypass MFA, SSO, approval workflows, captchas, IP allowlists, bastions, or least-privilege controls.
+
+This skill is optimized for a shared core workflow that can be reused in Codex, OpenClaw, and Claude Code. Codex-specific UI metadata lives in `agents/openai.yaml`; the operational logic stays in this `SKILL.md` plus the bundled references and scripts.
+
+## Use this skill when
+- You need to connect to a Linux instance through SSH, password SSH, `ProxyJump`, or a bastion.
+- You need file transfer, service/process checks, log inspection, restart operations, or access troubleshooting on an existing instance.
+- You need AWS EC2 or Aliyun ECS instance inspection or other cloud-side checks through the official CLI.
+- You need to deploy a model, stand up an API, validate output artifacts, or run cloud-side mutating actions **and the user has explicitly asked for that path**.
+
+## Required inputs
+Normalize each request into these five inputs before acting:
+1. **Target object**: host/IP, instance ID, region, environment, bastion
+2. **Cloud environment**: generic Linux, AWS, or Aliyun
+3. **Authentication method**: SSH key, password SSH, agent, AWS profile, Aliyun profile, short-lived token, SSO
+4. **Restrictions**: MFA, approval, allowlist, no public route, read-only, captcha, missing CLI, shared GPU/port use
+5. **Requested action**: connect, transfer, inspect, logs, restart, deploy, single-run, serve, accept, instance-check, cloud-op
+
+Treat `deploy`, `single-run`, `serve`, `accept`, and `cloud-op` as explicit-action modes. Do not enter them from a vague “帮我看看机器” style request without confirming intent from the user prompt or environment.
+
+If an input is missing, infer it from the environment first. Ask the user only for the minimum missing detail.
+
+## Core operating model
+
+### 1. Preflight
+Run a lightweight local check before attempting privileged or remote work.
+
+Typical commands:
+
+```bash
+python3 scripts/preflight.py --cloud generic --action inspect --host 10.0.0.8 --check-port
+python3 scripts/preflight.py --cloud aws --action instance-check --profile prod --region ap-southeast-1
+python3 scripts/preflight.py --cloud aliyun --action cloud-op --profile default --region cn-hangzhou
+```
+
+Preflight should verify only what is safe to verify locally:
+- required binaries exist
+- obvious credential sources exist
+- referenced files exist
+- target port is reachable when requested
+- explicit restrictions imply `blocked`, `denied`, or `needs_user`
+
+### 2. Execution
+Use the narrowest command that answers the request.
+- Prefer read-only checks before mutating actions.
+- Prefer official cloud CLI for cloud-level state changes.
+- For instance lifecycle operations on EC2/ECS, prefer provider CLI/API over in-guest reboot when cloud state matters.
+
+Useful wrappers:
+
+```bash
+python3 scripts/ssh_probe.py --host 10.0.0.8 --user ec2-user --identity-file ~/.ssh/prod.pem
+python3 scripts/remote_port_owner.py --port 8080
+```
+
+### 3. Restriction handling
+If the environment requires human involvement, stop and return a structured handoff instead of guessing.
+
+Common stop conditions:
+- MFA / SSO / captcha required
+- explicit approval required
+- IP allowlist or private-network-only path not yet satisfied
+- read-only permission for a mutating action
+- missing cloud CLI or profile
+- SSH key or bastion path unavailable
+- shared port/GPU is still occupied by another workload
+
+### 4. Handoff
+Return a stable contract for both success and blocked cases so the result can be reused in later handoff, approval, or postmortem steps.
+
+Minimum success shape:
+
+```json
+{
+  "status": "ok",
+  "action": "inspect",
+  "target": "10.0.0.8",
+  "evidence": {
+    "network": {"10.0.0.8:22": "open"}
+  },
+  "next_step": "Proceed with the requested read-only inspection."
+}
+```
+
+When blocked, return a concrete next step instead of guessing.
+
+Expected shape:
+
+```json
+{
+  "status": "blocked",
+  "reason": "Target port 22 is unreachable from the current machine.",
+  "next_step": "Connect through the approved bastion or ask for the current IP to be allowlisted.",
+  "evidence": {
+    "network": {"10.0.0.8:22": "closed"}
+  }
+}
+```
+
+Allowed `status` values:
+- `ok`
+- `blocked`
+- `denied`
+- `needs_user`
+- `unsupported`
+
+## Model deployment workflow
+Use this workflow whenever the task is “部署模型 / 起 API / 做题面验收 / 输出文件检查” instead of plain server ops.
+
+### Principle: single-run before serving
+Always verify the underlying model or command **once** before wrapping it in an API. Do not start with service orchestration unless the user explicitly asks for service-first diagnosis.
+
+### Recommended sequence
+1. **Read-only preflight**: model path, input path, GPU/CPU, memory, ports, dependency versions, existing services
+2. **Single-run check**: run one minimal inference locally or remotely and verify the base pipeline works
+3. **Service deployment**: only after single-run succeeds, expose HTTP/API/worker entrypoint
+4. **Example-request acceptance**: rerun the exact original `curl` or request shape from the task prompt
+5. **Output artifact check**: confirm files exist, size is reasonable, type matches expectation, contents are not obviously broken
+6. **Repeated-request stability**: repeat at least once to catch cold-start-only success or stale previous services
+
+### Final acceptance checklist
+Do not claim “deployed successfully” until all applicable checks pass:
+- health check or docs endpoint check
+- original example request check
+- output artifact check
+- repeated request stability check
+- service log sanity check
+
+Use the bundled scripts when helpful:
+
+```bash
+python3 scripts/remote_service_check.py --url http://127.0.0.1:8080/docs
+python3 scripts/artifact_check.py --path /data/exam/output.wav --kind audio
+python3 scripts/deployment_final_check.py --url http://127.0.0.1:8080/health --repeat 2
+```
+
+## Shared runtime hygiene
+In exam, benchmark, and shared-machine environments, assume the host may already have leftovers.
+
+Before reusing a port, GPU, or task directory:
+- identify the current port owner
+- identify old model/server processes
+- verify the endpoint is serving the intended workload, not a stale process
+- verify the current environment has enough free memory/disk/GPU for the next task
+
+Never assume “service started” means “new service is handling requests”. Always verify the response path.
+
+## Environment isolation
+Prefer one environment per task (`venv` or `conda`). If isolation is impossible:
+- record key dependency versions before installation
+- assess whether new packages may break existing services
+- avoid in-place upgrades of shared production environments unless the user explicitly accepts the risk
+
+## Password SSH guidance
+Password SSH is common in exam or public-IP environments. Use it carefully:
+- prefer secrets from environment variables, local temp files, or secure prompts
+- never write passwords into the repo, shell history, or final logs
+- distinguish network failure, host key issues, wrong password, and server-side auth restrictions
+- when automation is needed, use the smallest possible `expect` or similar wrapper and keep logs password-free
+
+## Interrupted run recovery
+When the task was interrupted, never restart blindly. First check:
+1. residual processes
+2. listening ports
+3. output file timestamps and sizes
+4. last service logs
+5. whether to resume or rebuild
+
+If artifacts and downloads are already present, prefer resume. If state is ambiguous or contaminated, clean and restart only the affected slice.
+
+## Remote script layout
+For longer remote tasks, prefer a predictable work layout such as:
+- `01_single_run.py`
+- `02_api.py`
+- `03_start.sh`
+- `04_selftest.sh`
+- `*.log`
+- `*.pid`
+
+Keep logs, PID files, and outputs in one task directory so interrupted runs are easy to inspect.
+
+## Guardrails
+- Never store secrets, tokens, or private keys in the repo.
+- Never claim success unless a command or probe actually succeeded.
+- Never attempt to bypass MFA, SSO, approval, captcha, or network policy.
+- Never execute destructive or high-blast-radius actions without explicit confirmation.
+- For deployment tasks, never claim success based only on “command exited 0”; validate the artifact or endpoint.
+
+### Confirmation required
+Treat these as confirmation-required even if technically possible:
+- terminating or releasing an instance
+- resetting or recreating disks, snapshots, images, or security groups
+- firewall/public exposure changes
+- forced restart/stop that may cause downtime
+- any action outside the user’s stated target environment
+
+## References
+Load only the reference relevant to the current task:
+- Generic Linux and SSH patterns: `references/generic-linux.md`
+- AWS EC2 patterns: `references/aws.md`
+- Aliyun ECS patterns: `references/aliyun.md`
+- Restriction diagnosis and handoff language: `references/restricted-access.md`
+- Installation and invocation checklist: `references/install-and-examples.md`
+- Model deployment workflow and acceptance: `references/model-deployment.md`
+- Shared runtime hygiene and environment isolation: `references/shared-runtime-hygiene.md`
+- Interrupted-run recovery patterns: `references/interrupted-run-recovery.md`
+
+## Scripts
+- `scripts/preflight.py`: local preflight checks and initial status classification
+- `scripts/ssh_probe.py`: non-destructive SSH connectivity/auth probe with optional bastion
+- `scripts/normalize_result.py`: normalize command outcomes into the shared status contract
+- `scripts/remote_port_owner.py`: inspect which local process is listening on a port
+- `scripts/artifact_check.py`: verify output artifacts exist and look reasonable
+- `scripts/deployment_final_check.py`: verify health/example endpoints and optional artifacts with repeat checks

--- a/skills/cloud-instance-ops/SKILL.md
+++ b/skills/cloud-instance-ops/SKILL.md
@@ -137,7 +137,7 @@ Do not claim “deployed successfully” until all applicable checks pass:
 Use the bundled scripts when helpful:
 
 ```bash
-python3 scripts/remote_service_check.py --url http://127.0.0.1:8080/docs
+curl -fsS http://127.0.0.1:8080/docs
 python3 scripts/artifact_check.py --path /data/exam/output.wav --kind audio
 python3 scripts/deployment_final_check.py --url http://127.0.0.1:8080/health --repeat 2
 ```
@@ -161,15 +161,20 @@ Prefer one environment per task (`venv` or `conda`). If isolation is impossible:
 
 ## Password SSH guidance
 Password SSH is common in exam or public-IP environments. Use it carefully:
-- choose the narrowest password source that the **current tool process can actually read**
+- prefer a **local secure input UI** for interactive password entry
+- for interactive operator workflows, default to **secure prompt + SSH master-connection reuse**
 - password source priority for Codex-style tool execution:
-  1. password explicitly provided by the user in the current chat turn
+  1. a local secure input UI (`prompt-password`) for the current task
   2. a user-provided local temp file path
   3. an environment variable that has been **verified visible** to the current tool process
-- before asking the user to `export` a password variable, run a tiny visibility check first; if the current tool process still cannot read it, do **not** ask the user to repeat the export—switch to a temp file or one-shot wrapper instead
-- if the user already provided the password in chat for the current task, it is acceptable to use it in a one-shot local wrapper or helper invocation, as long as it is not written to the repo, shell history, or final response
+- the recommended flow is: **bootstrap the SSH master session first, then execute the real remote command**
+- after the first successful login, reuse the SSH master connection for the same `thread_id + user@host:port` so later commands in the same thread do not re-prompt for the password
+- by default, a reused session stays alive until the operator explicitly closes it
+- if the first business command fails **after** bootstrap succeeds, do not ask for the password again; reuse the existing session for retries in the same thread
+- unless the user explicitly insists, do **not** ask them to paste passwords or other secrets directly into chat
+- before asking the user to `export` a password variable, run a tiny visibility check first; if the current tool process still cannot read it, do **not** ask the user to repeat the export—switch to secure prompt input or a temp file instead
 - never write passwords into the repo, shell history, or final logs
-- distinguish network failure, host key issues, wrong password, and server-side auth restrictions
+- distinguish authentication failure, session-bootstrap failure, and business-command failure
 - prefer a reusable helper script over ad-hoc multi-layer quoting when automation is needed
 - when `expect` or a similar wrapper is still required, keep the wrapper as small as possible and keep logs password-free
 
@@ -181,15 +186,29 @@ if [ -n "$CLOUD_INSTANCE_PASSWORD" ]; then echo set; else echo missing; fi
 
 Recommended helper usage:
 
+1. Bootstrap a session once per thread:
+
 ```bash
-python3 scripts/password_ssh.py \
-  --host 10.0.0.8 \
-  --user root \
-  --port 22 \
-  --password-file /tmp/cloud_instance_password \
-  --remote-command "hostname && whoami"
+python3 scripts/password_ssh.py   --host 10.0.0.8   --user root   --port 22   --prompt-password   --ensure-session
 ```
 
+2. Reuse that session for real commands:
+
+```bash
+python3 scripts/password_ssh.py   --host 10.0.0.8   --user root   --port 22   --remote-command "hostname && whoami"
+```
+
+3. Close the reused session explicitly when you are done:
+
+```bash
+python3 scripts/password_ssh.py   --host 10.0.0.8   --user root   --port 22   --close-session
+```
+
+Fallback modes:
+- for unattended automation: use `--password-file` or `--password-env`
+- for interactive operator workflows: prefer `--prompt-password` and `--ensure-session`
+- if the user wants one-shot behavior, disable session reuse explicitly with `--no-reuse-session`
+- sessions are thread-scoped by default; other threads do not reuse them unless a shared `--session-namespace` is explicitly provided
 ## Interrupted run recovery
 When the task was interrupted, never restart blindly. First check:
 1. residual processes
@@ -240,7 +259,7 @@ Load only the reference relevant to the current task:
 ## Scripts
 - `scripts/preflight.py`: local preflight checks and initial status classification
 - `scripts/ssh_probe.py`: non-destructive SSH connectivity/auth probe with optional bastion
-- `scripts/password_ssh.py`: reusable password-based SSH wrapper that prefers direct password input or temp files over fragile ad-hoc `expect` snippets
+- `scripts/password_ssh.py`: password-based SSH helper with secure prompt input, optional thread-scoped session reuse, and safer defaults for host key checking
 - `scripts/normalize_result.py`: normalize command outcomes into the shared status contract
 - `scripts/remote_port_owner.py`: inspect which local process is listening on a port
 - `scripts/artifact_check.py`: verify output artifacts exist and look reasonable

--- a/skills/cloud-instance-ops/SKILL.md
+++ b/skills/cloud-instance-ops/SKILL.md
@@ -161,10 +161,34 @@ Prefer one environment per task (`venv` or `conda`). If isolation is impossible:
 
 ## Password SSH guidance
 Password SSH is common in exam or public-IP environments. Use it carefully:
-- prefer secrets from environment variables, local temp files, or secure prompts
+- choose the narrowest password source that the **current tool process can actually read**
+- password source priority for Codex-style tool execution:
+  1. password explicitly provided by the user in the current chat turn
+  2. a user-provided local temp file path
+  3. an environment variable that has been **verified visible** to the current tool process
+- before asking the user to `export` a password variable, run a tiny visibility check first; if the current tool process still cannot read it, do **not** ask the user to repeat the export—switch to a temp file or one-shot wrapper instead
+- if the user already provided the password in chat for the current task, it is acceptable to use it in a one-shot local wrapper or helper invocation, as long as it is not written to the repo, shell history, or final response
 - never write passwords into the repo, shell history, or final logs
 - distinguish network failure, host key issues, wrong password, and server-side auth restrictions
-- when automation is needed, use the smallest possible `expect` or similar wrapper and keep logs password-free
+- prefer a reusable helper script over ad-hoc multi-layer quoting when automation is needed
+- when `expect` or a similar wrapper is still required, keep the wrapper as small as possible and keep logs password-free
+
+Recommended visibility check before relying on an env var:
+
+```bash
+if [ -n "$CLOUD_INSTANCE_PASSWORD" ]; then echo set; else echo missing; fi
+```
+
+Recommended helper usage:
+
+```bash
+python3 scripts/password_ssh.py \
+  --host 10.0.0.8 \
+  --user root \
+  --port 22 \
+  --password-file /tmp/cloud_instance_password \
+  --remote-command "hostname && whoami"
+```
 
 ## Interrupted run recovery
 When the task was interrupted, never restart blindly. First check:
@@ -216,6 +240,7 @@ Load only the reference relevant to the current task:
 ## Scripts
 - `scripts/preflight.py`: local preflight checks and initial status classification
 - `scripts/ssh_probe.py`: non-destructive SSH connectivity/auth probe with optional bastion
+- `scripts/password_ssh.py`: reusable password-based SSH wrapper that prefers direct password input or temp files over fragile ad-hoc `expect` snippets
 - `scripts/normalize_result.py`: normalize command outcomes into the shared status contract
 - `scripts/remote_port_owner.py`: inspect which local process is listening on a port
 - `scripts/artifact_check.py`: verify output artifacts exist and look reasonable

--- a/skills/cloud-instance-ops/agents/openai.yaml
+++ b/skills/cloud-instance-ops/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Cloud Instance Ops"
+  short_description: "Manage cloud instances safely across agents"
+  default_prompt: "Use $cloud-instance-ops to inspect, operate, and troubleshoot a cloud instance within the current access constraints."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/cloud-instance-ops/references/aliyun.md
+++ b/skills/cloud-instance-ops/references/aliyun.md
@@ -1,0 +1,30 @@
+# Aliyun ECS operations
+
+Use this reference when the request targets Alibaba Cloud ECS.
+
+## Prerequisites
+- Local `aliyun` CLI is installed.
+- Credentials come from an existing Aliyun profile, environment variables, or local CLI config.
+- Do not create or persist AccessKey material in the repo.
+
+## Preferred read-only commands
+```bash
+aliyun ecs DescribeInstances --RegionId <region> --InstanceIds '["<instance-id>"]' [--profile <profile>]
+aliyun ecs DescribeInstanceStatus --RegionId <region> --InstanceId.1 <instance-id> [--profile <profile>]
+```
+
+## Common lifecycle commands
+```bash
+aliyun ecs StartInstance --RegionId <region> --InstanceId <instance-id> [--profile <profile>]
+aliyun ecs StopInstance --RegionId <region> --InstanceId <instance-id> [--profile <profile>]
+aliyun ecs RebootInstance --RegionId <region> --InstanceId <instance-id> [--profile <profile>]
+```
+
+## Guidance
+- Prefer ECS CLI/API for start/stop/reboot when instance lifecycle state matters.
+- If the request is blocked by RAM policy, financial lock, or missing approval, stop and return a structured handoff.
+- If the CLI reports authentication problems, MFA-like interactive login, or missing profile setup, return `needs_user`.
+- Treat disk reset, image replacement, security group mutation, and public exposure changes as confirmation-required.
+
+## Source notes
+These command names align with the official Aliyun ECS CLI/API documentation for `DescribeInstances`, `DescribeInstanceStatus`, `StartInstance`, `StopInstance`, and `RebootInstance`.

--- a/skills/cloud-instance-ops/references/aws.md
+++ b/skills/cloud-instance-ops/references/aws.md
@@ -1,0 +1,30 @@
+# AWS EC2 operations
+
+Use this reference when the request targets AWS EC2 or related instance diagnostics.
+
+## Prerequisites
+- Local `aws` CLI is installed.
+- Credentials come from an existing profile, environment variables, or the local AWS config/credentials files.
+- Do not create or persist credentials in the repo.
+
+## Preferred read-only commands
+```bash
+aws ec2 describe-instances --instance-ids <instance-id> --region <region> [--profile <profile>]
+aws ec2 describe-instance-status --instance-ids <instance-id> --region <region> [--profile <profile>]
+```
+
+## Common lifecycle commands
+```bash
+aws ec2 start-instances --instance-ids <instance-id> --region <region> [--profile <profile>]
+aws ec2 stop-instances --instance-ids <instance-id> --region <region> [--profile <profile>]
+aws ec2 reboot-instances --instance-ids <instance-id> --region <region> [--profile <profile>]
+```
+
+## Guidance
+- Prefer EC2 CLI/API for start/stop/reboot when cloud-level instance state matters.
+- If the command fails with SSO, MFA, or expired credentials, return `needs_user` and tell the user to refresh the session.
+- If the command fails with `UnauthorizedOperation` or `AccessDenied`, return `denied`.
+- Avoid terminate, security group mutation, EBS replacement, or AMI/image changes unless explicitly requested and confirmed.
+
+## Source notes
+These command names align with the official AWS CLI EC2 references for `describe-instances`, `describe-instance-status`, `start-instances`, `stop-instances`, and `reboot-instances`.

--- a/skills/cloud-instance-ops/references/generic-linux.md
+++ b/skills/cloud-instance-ops/references/generic-linux.md
@@ -1,0 +1,39 @@
+# Generic Linux / SSH operations
+
+Use this reference for ordinary Linux instance work when SSH is the main control plane.
+
+## Preferred sequence
+1. Confirm target, user, network path, and auth source.
+2. Probe connectivity before making assumptions.
+3. Start with read-only commands.
+4. Mutate only after the user has requested the action.
+5. Summarize outcome with `status`, `reason`, `next_step`, and `evidence`.
+
+## Common read-only commands
+```bash
+whoami
+hostname
+uname -a
+id
+pwd
+ls -la
+ps aux
+ss -tulpn
+systemctl status <service>
+journalctl -u <service> -n 200 --no-pager
+df -h
+free -m
+```
+
+## Common safe operational patterns
+- Service restart: `sudo systemctl restart <service>`
+- Service logs: `journalctl -u <service> -n 200 --no-pager`
+- File transfer in: `scp <local> <user>@<host>:<remote>`
+- File transfer out: `scp <user>@<host>:<remote> <local>`
+- Bastion path: prefer `ssh -J <jump_host> <user>@<host>`
+
+## Stop instead of guessing when
+- SSH fails due to `Permission denied`, key mismatch, host key mismatch, or missing bastion
+- Port 22 is unreachable or routed only inside a VPC/VPN
+- `sudo` prompts for an unavailable password
+- The requested action is destructive or affects uptime without confirmation

--- a/skills/cloud-instance-ops/references/install-and-examples.md
+++ b/skills/cloud-instance-ops/references/install-and-examples.md
@@ -221,7 +221,7 @@ EOF
 ### 10.1 Single-run before serving
 ```bash
 python3 scripts/remote_port_owner.py --port 8080
-python3 scripts/remote_service_check.py --url http://127.0.0.1:8080/docs --expect-status 200
+curl -fsS http://127.0.0.1:8080/docs
 ```
 
 ### 10.2 Artifact check

--- a/skills/cloud-instance-ops/references/install-and-examples.md
+++ b/skills/cloud-instance-ops/references/install-and-examples.md
@@ -1,0 +1,236 @@
+# Installation and usage examples
+
+Use this reference when you need a compact checklist for setting up or invoking `cloud-instance-ops`.
+
+## 1. Installation / placement checklist
+
+### Codex
+Place the skill directory where Codex can access local skills, or keep it in a workspace and invoke it explicitly if your setup supports local skill loading.
+
+Expected directory shape:
+
+```text
+cloud-instance-ops/
+├── SKILL.md
+├── agents/openai.yaml
+├── references/
+└── scripts/
+```
+
+### OpenClaw / Claude Code
+Reuse the same `cloud-instance-ops/` directory as the shared core skill. If your local setup expects a dedicated skills path, copy or symlink the whole folder there rather than splitting files.
+
+## 2. Local prerequisites checklist
+- Python 3 available locally
+- `ssh` installed for Linux instance operations
+- `scp` installed for file transfer / deploy flows
+- `aws` CLI installed for AWS EC2 operations
+- `aliyun` CLI installed for Aliyun ECS operations
+- Existing credential source already configured locally:
+  - SSH key / ssh-agent / SSH config
+  - AWS profile or environment credentials
+  - Aliyun profile or environment credentials
+- Optional but common:
+  - VPN connectivity
+  - bastion / jump host
+  - approved IP allowlist
+
+## 3. Recommended invocation sequence
+For any new target, prefer this order:
+
+1. Run `preflight.py`
+2. If SSH-based, run `ssh_probe.py`
+3. Run the smallest real command
+4. If the command fails, normalize it with `normalize_result.py`
+
+## 4. Generic Linux examples
+
+### 4.1 Check whether a host is reachable
+```bash
+python3 scripts/preflight.py \
+  --cloud generic \
+  --action inspect \
+  --host 10.0.0.8 \
+  --check-port
+```
+
+### 4.2 Probe SSH auth without making changes
+```bash
+python3 scripts/ssh_probe.py \
+  --host 10.0.0.8 \
+  --user ubuntu \
+  --identity-file ~/.ssh/prod.pem
+```
+
+### 4.3 Probe through a bastion
+```bash
+python3 scripts/preflight.py \
+  --cloud generic \
+  --action inspect \
+  --host 10.0.1.15 \
+  --jump-host bastion.example.com \
+  --check-port
+
+python3 scripts/ssh_probe.py \
+  --host 10.0.1.15 \
+  --user ec2-user \
+  --identity-file ~/.ssh/prod.pem \
+  --jump-host bastion.example.com
+```
+
+### 4.4 Normalize a failed SSH result
+```bash
+python3 scripts/normalize_result.py \
+  --exit-code 255 \
+  --stderr 'Permission denied (publickey)' \
+  --command 'ssh -i ~/.ssh/prod.pem ec2-user@10.0.0.8'
+```
+
+## 5. AWS examples
+
+### 5.1 Check local AWS readiness
+```bash
+python3 scripts/preflight.py \
+  --cloud aws \
+  --action instance-check \
+  --profile prod \
+  --region ap-southeast-1
+```
+
+### 5.2 Describe an EC2 instance
+```bash
+aws ec2 describe-instances \
+  --instance-ids i-0123456789abcdef0 \
+  --region ap-southeast-1 \
+  --profile prod
+```
+
+### 5.3 Reboot an EC2 instance
+```bash
+aws ec2 reboot-instances \
+  --instance-ids i-0123456789abcdef0 \
+  --region ap-southeast-1 \
+  --profile prod
+```
+
+### 5.4 Normalize an AWS auth/session failure
+```bash
+python3 scripts/normalize_result.py \
+  --exit-code 254 \
+  --stderr 'SSO login required or session token has expired' \
+  --command 'aws ec2 describe-instances --instance-ids i-0123456789abcdef0 --region ap-southeast-1 --profile prod'
+```
+
+## 6. Aliyun examples
+
+### 6.1 Check local Aliyun readiness
+```bash
+python3 scripts/preflight.py \
+  --cloud aliyun \
+  --action instance-check \
+  --profile default \
+  --region cn-hangzhou
+```
+
+### 6.2 Describe an ECS instance
+```bash
+aliyun ecs DescribeInstances \
+  --RegionId cn-hangzhou \
+  --InstanceIds '["i-bp1example123456789"]' \
+  --profile default
+```
+
+### 6.3 Reboot an ECS instance
+```bash
+aliyun ecs RebootInstance \
+  --RegionId cn-hangzhou \
+  --InstanceId i-bp1example123456789 \
+  --profile default
+```
+
+### 6.4 Normalize an Aliyun permission failure
+```bash
+python3 scripts/normalize_result.py \
+  --exit-code 1 \
+  --stderr 'AccessDenied: You are not authorized to perform this action.' \
+  --command 'aliyun ecs RebootInstance --RegionId cn-hangzhou --InstanceId i-bp1example123456789 --profile default'
+```
+
+## 7. Restricted-access examples
+
+### MFA / SSO / approval known in advance
+```bash
+python3 scripts/preflight.py \
+  --cloud aws \
+  --action cloud-op \
+  --profile prod \
+  --region ap-southeast-1 \
+  --restrictions mfa,sso,approval
+```
+
+### Read-only access trying a mutating action
+```bash
+python3 scripts/preflight.py \
+  --cloud generic \
+  --action restart \
+  --host 10.0.0.8 \
+  --restrictions read-only
+```
+
+### Allowlist or VPN restriction without bastion
+```bash
+python3 scripts/preflight.py \
+  --cloud generic \
+  --action inspect \
+  --host 10.0.1.15 \
+  --restrictions allowlist,vpn \
+  --check-port
+```
+
+## 8. What not to do
+- Do not put secrets into the skill directory.
+- Do not treat browser-only console workflows as the default path.
+- Do not skip preflight when access constraints are unclear.
+- Do not claim success on the basis of assumptions.
+
+
+## 9. Password SSH examples
+
+### 9.1 Keep the password out of the repo
+Preferred sources:
+- environment variable for the current shell only
+- local secret temp file outside the repo
+- secure prompt or desktop secret storage
+
+### 9.2 Minimal `expect` probe pattern
+```bash
+expect <<'EOF'
+log_user 0
+set timeout 20
+set password $env(CLOUD_INSTANCE_PASSWORD)
+spawn ssh -o StrictHostKeyChecking=accept-new ubuntu@122.51.187.199 true
+expect {
+  -re ".*assword:.*" { send -- "$password\r"; exp_continue }
+  eof { catch wait result; exit [lindex $result 3] }
+}
+EOF
+```
+
+## 10. Model deployment examples
+
+### 10.1 Single-run before serving
+```bash
+python3 scripts/remote_port_owner.py --port 8080
+python3 scripts/remote_service_check.py --url http://127.0.0.1:8080/docs --expect-status 200
+```
+
+### 10.2 Artifact check
+```bash
+python3 scripts/artifact_check.py --path /data/exam/output.wav --kind audio --min-size 1024
+python3 scripts/artifact_check.py --path /data/exam/result.txt --kind text --min-size 20
+```
+
+### 10.3 Final acceptance check
+```bash
+python3 scripts/deployment_final_check.py   --url http://127.0.0.1:8080/health   --repeat 2   --artifact /data/exam/output.wav   --artifact-kind audio
+```

--- a/skills/cloud-instance-ops/references/interrupted-run-recovery.md
+++ b/skills/cloud-instance-ops/references/interrupted-run-recovery.md
@@ -1,0 +1,33 @@
+# Interrupted run recovery
+
+Use this reference when the user switched threads, interrupted commands, or the desktop session was closed.
+
+## Recovery checklist
+1. check residual processes
+2. check listening ports
+3. check output file timestamps and sizes
+4. check service logs and last error
+5. decide whether to resume or rebuild
+
+## Prefer resume when
+- downloads are still in progress or already complete
+- artifacts exist and look current
+- the service is still running and healthy
+- the environment is otherwise clean
+
+## Prefer rebuild when
+- the port is occupied by an unknown process
+- the environment is clearly contaminated
+- output files are stale or mismatched
+- logs show repeated crash loops from corrupted state
+
+## Minimal commands to inspect first
+```bash
+ps -ef | grep -E 'service_name|python|node' | grep -v grep
+ss -tulpn | grep ':8080 '
+ls -lh <artifact>
+tail -n 200 <service.log>
+```
+
+## Recovery claim rules
+Never say "we can resume" without evidence. Never say "clean restart required" without identifying the stale state.

--- a/skills/cloud-instance-ops/references/model-deployment.md
+++ b/skills/cloud-instance-ops/references/model-deployment.md
@@ -1,0 +1,46 @@
+# Model deployment workflow
+
+Use this reference for model deployment, exam, benchmark, or API-serving tasks.
+
+## Default principle
+**Single-run before serving.**
+
+Do not start with API orchestration unless the task is explicitly about service debugging. First prove that the base model, command, or script works once.
+
+## Recommended sequence
+1. Read-only preflight
+2. Single-run validation
+3. Service deployment
+4. Original example request validation
+5. Output artifact validation
+6. Repeated-request stability validation
+
+## Preflight checklist
+- model files exist and paths are correct
+- inputs exist and formats match the task
+- CPU/GPU/memory/disk are sufficient
+- target port is free or intentionally reused
+- dependency versions are known
+- old services/processes are identified
+
+## Final acceptance checklist
+Do not say "done" until you have all applicable evidence:
+- health/docs endpoint works
+- original `curl` or request from the task prompt works
+- output file exists
+- output file size/type/basic content are reasonable
+- repeated request also works
+- logs do not show obvious repeated crashes
+
+## Output reasonableness rules
+- **TTS**: non-empty output, plausible duration, sample rate/channel count if available, file size not tiny
+- **ASR**: text is non-empty and not obviously truncated or garbled
+- **Image generation**: file format, dimensions, and size are plausible
+- **Text generation**: length meets expectations and does not leak hidden reasoning or placeholders
+- **OCR / parsing**: result is non-empty, structure is plausible, and exported files exist if the task requires them
+
+## Deployment claim rules
+- `command succeeded` is not enough
+- `service started` is not enough
+- `port is listening` is not enough
+- only claim success when **request + artifact + repeatability** all pass

--- a/skills/cloud-instance-ops/references/restricted-access.md
+++ b/skills/cloud-instance-ops/references/restricted-access.md
@@ -1,0 +1,29 @@
+# Restricted access diagnosis
+
+Use this reference to map access symptoms to a stable response.
+
+## Status mapping
+- `ok`: the required local preconditions and command/probe succeeded
+- `blocked`: a technical path exists in principle, but the current environment cannot reach or use it
+- `denied`: the current identity lacks permission for the requested mutating action
+- `needs_user`: a human must complete MFA, SSO, captcha, approval, or another interactive step
+- `unsupported`: the requested environment or tooling is outside this skill's supported scope
+
+## Symptom → status
+- `Permission denied (publickey)` with no valid key path: `blocked`
+- `Connection timed out`, `No route to host`, allowlist miss, private endpoint only: `blocked`
+- `AccessDenied`, `UnauthorizedOperation`, RAM deny: `denied`
+- `SSO login required`, `MFA required`, approval/captcha prompt: `needs_user`
+- Missing `aws`, `aliyun`, or `ssh` binary when the task depends on it: `unsupported`
+
+## Handoff language patterns
+- **blocked**: explain the missing path or dependency, then name the smallest next step
+- **denied**: name the permission boundary and the exact action that needs approval
+- **needs_user**: say which interactive step is required and stop
+- **unsupported**: say what this skill supports and what is out of scope
+
+## Example next steps
+- "Run the approved SSO login flow for the `prod` profile, then retry the command."
+- "Provide the bastion hostname or connect this machine to the required VPN."
+- "Ask for `ec2:RebootInstances` or `ecs:RebootInstance` on the target instance before retrying."
+- "Install the required CLI locally, then rerun preflight."

--- a/skills/cloud-instance-ops/references/shared-runtime-hygiene.md
+++ b/skills/cloud-instance-ops/references/shared-runtime-hygiene.md
@@ -1,0 +1,38 @@
+# Shared runtime hygiene
+
+Use this reference for reused machines, shared GPUs, repeated exam tasks, or mixed workloads.
+
+## Port hygiene
+Before binding a port:
+- identify the current owner (`ss -tulpn`, `lsof`, or `fuser`)
+- confirm the currently responding endpoint is the intended service
+- avoid false success where an old service still answers new requests
+
+## GPU / accelerator hygiene
+Before launching a new model:
+- check device occupancy and memory use
+- identify stale inference servers
+- free only the processes relevant to the current task
+- do not assume "GPU present" means "GPU available"
+
+## Dependency isolation
+Prefer one `venv` or `conda` env per task. If not possible:
+- snapshot key versions first
+- avoid broad upgrades in shared environments
+- expect packages like `transformers`, `diffusers`, `opencv`, `pydantic`, and inference runtimes to conflict
+
+## Script / file layout
+For remote task directories, prefer stable naming:
+- `01_single_run.py`
+- `02_api.py`
+- `03_start.sh`
+- `04_selftest.sh`
+- `service.log`
+- `service.pid`
+- `outputs/`
+
+## Cleanup rules
+Clean only what you can attribute.
+- stop the old service by PID or unit name
+- remove stale PID files only after verifying the process is gone
+- keep logs until acceptance is complete

--- a/skills/cloud-instance-ops/scripts/artifact_check.py
+++ b/skills/cloud-instance-ops/scripts/artifact_check.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Check whether an output artifact exists and looks reasonable."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+def detect_kind(path: Path, explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    suffix = path.suffix.lower()
+    if suffix in {'.wav', '.mp3', '.flac', '.m4a', '.ogg'}:
+        return 'audio'
+    if suffix in {'.png', '.jpg', '.jpeg', '.webp'}:
+        return 'image'
+    if suffix in {'.txt', '.md', '.json'}:
+        return 'text'
+    return 'generic'
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Artifact reasonableness check')
+    parser.add_argument('--path', required=True)
+    parser.add_argument('--kind', choices=['audio', 'image', 'text', 'generic'])
+    parser.add_argument('--min-size', type=int, default=1)
+    parser.add_argument('--max-size', type=int)
+    args = parser.parse_args()
+
+    path = Path(args.path).expanduser()
+    evidence = {'path': str(path), 'exists': path.exists(), 'kind': detect_kind(path, args.kind)}
+
+    if not path.exists():
+        print(json.dumps({
+            'status': 'blocked',
+            'reason': f'Artifact does not exist: {path}.',
+            'next_step': 'Verify the output path and rerun the generating request.',
+            'evidence': evidence,
+        }, ensure_ascii=False, indent=2))
+        return 0
+
+    size = path.stat().st_size
+    evidence['size_bytes'] = size
+    evidence['suffix'] = path.suffix.lower()
+
+    if size < args.min_size:
+        print(json.dumps({
+            'status': 'blocked',
+            'reason': f'Artifact exists but is smaller than expected ({size} bytes).',
+            'next_step': 'Inspect the generating request and verify the artifact is complete.',
+            'evidence': evidence,
+        }, ensure_ascii=False, indent=2))
+        return 0
+
+    if args.max_size and size > args.max_size:
+        print(json.dumps({
+            'status': 'blocked',
+            'reason': f'Artifact exists but is larger than the configured upper bound ({size} bytes).',
+            'next_step': 'Verify the artifact type and confirm the output is not malformed.',
+            'evidence': evidence,
+        }, ensure_ascii=False, indent=2))
+        return 0
+
+    if evidence['kind'] == 'text':
+        try:
+            preview = path.read_text(encoding='utf-8', errors='ignore')[:200]
+        except Exception:
+            preview = ''
+        evidence['preview'] = preview
+        if not preview.strip():
+            print(json.dumps({
+                'status': 'blocked',
+                'reason': 'Text artifact exists but appears empty or whitespace-only.',
+                'next_step': 'Verify the task really produced text and rerun the request if needed.',
+                'evidence': evidence,
+            }, ensure_ascii=False, indent=2))
+            return 0
+
+    print(json.dumps({
+        'status': 'ok',
+        'reason': 'Artifact exists and passed the configured basic checks.',
+        'next_step': 'If this is a final acceptance path, also validate the original example request and repeat once.',
+        'evidence': evidence,
+    }, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/skills/cloud-instance-ops/scripts/deployment_final_check.py
+++ b/skills/cloud-instance-ops/scripts/deployment_final_check.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Final acceptance checks for deployed services."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def probe(url: str, timeout: int) -> tuple[bool, int | None, str]:
+    req = urllib.request.Request(url, method='GET')
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read(256)
+            return True, resp.status, body.decode('utf-8', 'ignore')
+    except urllib.error.HTTPError as e:
+        return False, e.code, str(e)
+    except Exception as e:
+        return False, None, repr(e)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Deployment final acceptance check')
+    parser.add_argument('--url', required=True)
+    parser.add_argument('--repeat', type=int, default=2)
+    parser.add_argument('--expect-status', type=int, default=200)
+    parser.add_argument('--artifact')
+    parser.add_argument('--artifact-kind', choices=['audio', 'image', 'text', 'generic'], default='generic')
+    parser.add_argument('--min-artifact-size', type=int, default=1)
+    parser.add_argument('--timeout', type=int, default=30)
+    args = parser.parse_args()
+
+    evidence = {'url': args.url, 'probes': [], 'artifact': None}
+
+    for i in range(args.repeat):
+        ok, status, detail = probe(args.url, args.timeout)
+        evidence['probes'].append({'attempt': i + 1, 'ok': ok, 'status': status, 'detail': detail[:200]})
+        if not ok or status != args.expect_status:
+            print(json.dumps({
+                'status': 'blocked',
+                'reason': f'HTTP probe failed on attempt {i + 1}.',
+                'next_step': 'Inspect service logs, verify the intended service owns the port, and retry the original request.',
+                'evidence': evidence,
+            }, ensure_ascii=False, indent=2))
+            return 0
+        time.sleep(1)
+
+    if args.artifact:
+        path = Path(args.artifact).expanduser()
+        artifact = {'path': str(path), 'exists': path.exists(), 'kind': args.artifact_kind}
+        evidence['artifact'] = artifact
+        if not path.exists():
+            print(json.dumps({
+                'status': 'blocked',
+                'reason': 'Artifact path was provided but the file does not exist.',
+                'next_step': 'Verify the output path and rerun the original example request.',
+                'evidence': evidence,
+            }, ensure_ascii=False, indent=2))
+            return 0
+        artifact['size_bytes'] = path.stat().st_size
+        if artifact['size_bytes'] < args.min_artifact_size:
+            print(json.dumps({
+                'status': 'blocked',
+                'reason': 'Artifact exists but is smaller than the configured minimum size.',
+                'next_step': 'Inspect the generated artifact and confirm the service really produced the expected output.',
+                'evidence': evidence,
+            }, ensure_ascii=False, indent=2))
+            return 0
+
+    print(json.dumps({
+        'status': 'ok',
+        'reason': 'Service probes succeeded and the optional artifact check passed.',
+        'next_step': 'If the task provided a raw curl example, rerun that exact request before final sign-off.',
+        'evidence': evidence,
+    }, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/skills/cloud-instance-ops/scripts/normalize_result.py
+++ b/skills/cloud-instance-ops/scripts/normalize_result.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Normalize command outcomes into the shared status contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def normalize(exit_code: int, stdout: str, stderr: str) -> tuple[str, str, str]:
+    text = f"{stdout}\n{stderr}".lower()
+
+    if exit_code == 0:
+        return "ok", "Command completed successfully.", "Proceed to the next requested step."
+
+    if any(token in text for token in ("mfa", "multi-factor", "verification code", "sso login", "device code", "browser login", "approval", "captcha")):
+        return "needs_user", "The command requires an interactive login, approval, or verification step.", "Complete the required interactive step, then rerun the command."
+
+    if any(token in text for token in ("accessdenied", "unauthorizedoperation", "permission denied by policy", "forbidden", "not authorized", "ram")):
+        return "denied", "The current identity is not authorized for this action.", "Request the minimum required permission or approval, then retry."
+
+    if any(token in text for token in ("publickey", "permission denied", "host key verification failed", "expiredtoken", "token has expired", "session token", "connection timed out", "no route to host", "connection refused", "not in whitelist", "network is unreachable")):
+        return "blocked", "The current environment cannot complete the command with the available network or credentials.", "Fix the access path, refresh credentials, or use the approved bastion/VPN flow, then retry."
+
+    if any(token in text for token in ("command not found", "unknown option", "unknown command", "not supported")):
+        return "unsupported", "The required local tooling or command shape is not supported in the current environment.", "Install the required tool or adjust the command to a supported form, then retry."
+
+    return "blocked", "Command failed and needs investigation.", "Inspect stderr and the environment, then retry with the smallest reproducible command."
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Normalize command outcomes")
+    parser.add_argument("--exit-code", type=int, required=True)
+    parser.add_argument("--stdout", default="")
+    parser.add_argument("--stderr", default="")
+    parser.add_argument("--command", default="")
+    args = parser.parse_args()
+
+    stdout = args.stdout
+    stderr = args.stderr
+
+    if not stdout and not stderr and not sys.stdin.isatty():
+        stderr = sys.stdin.read()
+
+    status, reason, next_step = normalize(args.exit_code, stdout, stderr)
+    result = {
+        "status": status,
+        "reason": reason,
+        "next_step": next_step,
+        "evidence": {
+            "command": args.command,
+            "exit_code": args.exit_code,
+            "stdout": stdout.strip(),
+            "stderr": stderr.strip(),
+        },
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/cloud-instance-ops/scripts/password_ssh.py
+++ b/skills/cloud-instance-ops/scripts/password_ssh.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Reusable password-based SSH wrapper for cloud-instance-ops."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run an SSH command using a password without persisting secrets to the repo")
+    parser.add_argument("--host", required=True)
+    parser.add_argument("--user", required=True)
+    parser.add_argument("--port", type=int, default=22)
+    parser.add_argument("--password")
+    parser.add_argument("--password-file")
+    parser.add_argument("--password-env")
+    parser.add_argument("--remote-command", default="true")
+    parser.add_argument("--connect-timeout", type=int, default=10)
+    parser.add_argument("--strict-host-key-checking", choices=("yes", "no", "accept-new"), default="no")
+    parser.add_argument("--known-hosts-file")
+    parser.add_argument("--batch-json", action="store_true", help="Emit structured JSON instead of raw remote stdout/stderr passthrough")
+    return parser.parse_args()
+
+
+def resolve_password(args: argparse.Namespace) -> str:
+    if args.password is not None:
+        return args.password
+
+    if args.password_file:
+        return Path(args.password_file).expanduser().read_text(encoding="utf-8").strip()
+
+    if args.password_env:
+        value = os.getenv(args.password_env)
+        if value:
+            return value
+        raise SystemExit(f"password env var '{args.password_env}' is not visible to the current process")
+
+    raise SystemExit("one of --password, --password-file, or --password-env is required")
+
+
+def build_expect_script(password: str, ssh_command: list[str]) -> str:
+    quoted_command = " ".join(shlex.quote(part) for part in ssh_command)
+    escaped_password = password.replace("\\", "\\\\").replace('"', '\\"')
+    return f"""set timeout -1
+set pass "{escaped_password}"
+spawn {quoted_command}
+expect {{
+  -re {{[Pp]assword:}} {{ send "$pass\\r"; exp_continue }}
+  eof
+}}
+"""
+
+
+def classify(exit_code: int, stdout: str, stderr: str) -> tuple[str, str]:
+    text = f"{stdout}\n{stderr}".lower()
+    if exit_code == 0:
+        return "ok", "Password SSH command succeeded."
+    if "permission denied" in text:
+        return "blocked", "Password SSH authentication failed."
+    if any(token in text for token in ("connection refused", "connection timed out", "no route to host", "could not resolve hostname")):
+        return "blocked", "The current machine cannot reach the SSH endpoint."
+    if "host key verification failed" in text:
+        return "blocked", "SSH host key verification failed."
+    return "blocked", "Password SSH command failed."
+
+
+def main() -> int:
+    args = parse_args()
+
+    if shutil.which("expect") is None:
+        raise SystemExit("expect is required but was not found in PATH")
+    if shutil.which("ssh") is None:
+        raise SystemExit("ssh is required but was not found in PATH")
+
+    password = resolve_password(args)
+
+    ssh_command = [
+        "ssh",
+        "-o",
+        f"StrictHostKeyChecking={args.strict_host_key_checking}",
+        "-o",
+        f"ConnectTimeout={args.connect_timeout}",
+        "-p",
+        str(args.port),
+    ]
+    if args.known_hosts_file:
+        ssh_command.extend(["-o", f"UserKnownHostsFile={Path(args.known_hosts_file).expanduser()}"])
+    ssh_command.extend([f"{args.user}@{args.host}", args.remote_command])
+
+    script_text = build_expect_script(password, ssh_command)
+
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, suffix=".exp") as handle:
+        handle.write(script_text)
+        script_path = handle.name
+
+    try:
+        completed = subprocess.run(
+            ["expect", script_path],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        Path(script_path).unlink(missing_ok=True)
+
+    if not args.batch_json:
+        sys.stdout.write(completed.stdout)
+        sys.stderr.write(completed.stderr)
+        return completed.returncode
+
+    status, reason = classify(completed.returncode, completed.stdout, completed.stderr)
+    result = {
+        "status": status,
+        "reason": reason,
+        "evidence": {
+            "command": shlex.join(ssh_command),
+            "exit_code": completed.returncode,
+            "stdout": completed.stdout.strip(),
+            "stderr": completed.stderr.strip(),
+        },
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/cloud-instance-ops/scripts/password_ssh.py
+++ b/skills/cloud-instance-ops/scripts/password_ssh.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import getpass
+import hashlib
 import json
 import os
 import shlex
@@ -11,29 +13,46 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 
+class PromptError(RuntimeError):
+    """Raised when secure prompting fails."""
+
+
+CODEX_THREAD_ENV = "CODEX_THREAD_ID"
+
+
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run an SSH command using a password without persisting secrets to the repo")
+    parser = argparse.ArgumentParser(description="Run an SSH command using a securely prompted password without persisting secrets to the repo")
     parser.add_argument("--host", required=True)
     parser.add_argument("--user", required=True)
     parser.add_argument("--port", type=int, default=22)
-    parser.add_argument("--password")
     parser.add_argument("--password-file")
     parser.add_argument("--password-env")
+    parser.add_argument("--prompt-password", action="store_true")
+    parser.add_argument("--prompt-mode", choices=("auto", "gui", "tty"), default="auto")
+    parser.add_argument("--prompt-title", default="Cloud Instance Password")
+    parser.add_argument("--prompt-text", default="请输入 SSH 密码")
+    parser.add_argument("--reuse-session", action="store_true")
+    parser.add_argument("--no-reuse-session", action="store_true")
+    parser.add_argument("--ensure-session", action="store_true")
+    parser.add_argument("--session-root")
+    parser.add_argument("--session-name")
+    parser.add_argument("--session-namespace")
+    parser.add_argument("--close-session", action="store_true")
+    parser.add_argument("--check-session", action="store_true")
+    parser.add_argument("--session-status-json", action="store_true")
     parser.add_argument("--remote-command", default="true")
     parser.add_argument("--connect-timeout", type=int, default=10)
-    parser.add_argument("--strict-host-key-checking", choices=("yes", "no", "accept-new"), default="no")
+    parser.add_argument("--strict-host-key-checking", choices=("yes", "no", "accept-new"), default="accept-new")
     parser.add_argument("--known-hosts-file")
     parser.add_argument("--batch-json", action="store_true", help="Emit structured JSON instead of raw remote stdout/stderr passthrough")
     return parser.parse_args()
 
 
 def resolve_password(args: argparse.Namespace) -> str:
-    if args.password is not None:
-        return args.password
-
     if args.password_file:
         return Path(args.password_file).expanduser().read_text(encoding="utf-8").strip()
 
@@ -43,20 +62,92 @@ def resolve_password(args: argparse.Namespace) -> str:
             return value
         raise SystemExit(f"password env var '{args.password_env}' is not visible to the current process")
 
-    raise SystemExit("one of --password, --password-file, or --password-env is required")
+    if args.prompt_password:
+        return prompt_for_password(args.prompt_mode, args.prompt_title, args.prompt_text)
+
+    raise SystemExit("one of --prompt-password, --password-file, or --password-env is required")
+
+
+def prompt_for_password(mode: str, title: str, text: str) -> str:
+    if mode == "gui":
+        return prompt_password_gui(title, text)
+    if mode == "tty":
+        return prompt_password_tty(title, text)
+
+    gui_error: PromptError | None = None
+    try:
+        return prompt_password_gui(title, text)
+    except PromptError as exc:
+        gui_error = exc
+
+    try:
+        return prompt_password_tty(title, text)
+    except PromptError as tty_error:
+        raise PromptError(f"{gui_error}; fallback tty prompt failed: {tty_error}") from tty_error
+
+
+def prompt_password_gui(title: str, text: str) -> str:
+    osascript = shutil.which("osascript")
+    if not osascript:
+        raise PromptError("GUI prompt is unavailable because osascript was not found")
+
+    command = [
+        osascript,
+        "-e",
+        f'display dialog "{escape_applescript(text)}" default answer "" with hidden answer buttons {{"Cancel", "OK"}} default button "OK" with title "{escape_applescript(title)}"',
+        "-e",
+        "text returned of result",
+    ]
+    completed = subprocess.run(command, capture_output=True, text=True)
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip() or completed.stdout.strip()
+        raise PromptError(f"GUI prompt failed or was cancelled: {stderr or 'unknown error'}")
+    value = completed.stdout.strip()
+    if not value:
+        raise PromptError("GUI prompt returned an empty password")
+    return value
+
+
+def prompt_password_tty(title: str, text: str) -> str:
+    if not sys.stdin.isatty():
+        raise PromptError("TTY prompt is unavailable because stdin is not interactive")
+
+    prompt = f"[{title}] {text}: "
+    try:
+        value = getpass.getpass(prompt)
+    except (EOFError, KeyboardInterrupt) as exc:
+        raise PromptError("TTY prompt failed or was cancelled") from exc
+    if not value:
+        raise PromptError("TTY prompt returned an empty password")
+    return value
+
+
+def escape_applescript(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def tcl_list_literal(parts: list[str]) -> str:
+    return " ".join("{" + part.replace("\\", "\\\\").replace("}", "\\}") + "}" for part in parts)
 
 
 def build_expect_script(password: str, ssh_command: list[str]) -> str:
-    quoted_command = " ".join(shlex.quote(part) for part in ssh_command)
     escaped_password = password.replace("\\", "\\\\").replace('"', '\\"')
-    return f"""set timeout -1
+    cmd_literal = tcl_list_literal(ssh_command)
+    return f'''set timeout -1
 set pass "{escaped_password}"
-spawn {quoted_command}
+set cmd [list {cmd_literal}]
+eval spawn $cmd
 expect {{
   -re {{[Pp]assword:}} {{ send "$pass\\r"; exp_continue }}
   eof
 }}
-"""
+'''
+
+
+def redact_secret(text: str, secret: str | None) -> str:
+    if not text or not secret:
+        return text
+    return text.replace(secret, "[REDACTED]")
 
 
 def classify(exit_code: int, stdout: str, stderr: str) -> tuple[str, str]:
@@ -72,17 +163,49 @@ def classify(exit_code: int, stdout: str, stderr: str) -> tuple[str, str]:
     return "blocked", "Password SSH command failed."
 
 
-def main() -> int:
-    args = parse_args()
+def classify_command_failure(exit_code: int, stdout: str, stderr: str) -> tuple[str, str]:
+    text = f"{stdout}\n{stderr}".lower()
+    if exit_code == 0:
+        return "ok", "SSH command succeeded via existing session."
+    if any(token in text for token in ("master session", "control socket", "mux_client_request_session")):
+        return "blocked", "Existing SSH master session could not be reused."
+    return "blocked", "Remote command failed after session bootstrap."
 
-    if shutil.which("expect") is None:
-        raise SystemExit("expect is required but was not found in PATH")
-    if shutil.which("ssh") is None:
-        raise SystemExit("ssh is required but was not found in PATH")
 
-    password = resolve_password(args)
+def default_session_root() -> Path:
+    return Path("/tmp/cloud-instance-ops-sessions")
 
-    ssh_command = [
+
+def resolve_session_namespace(args: argparse.Namespace) -> tuple[str, str]:
+    if args.session_namespace:
+        return args.session_namespace, "explicit"
+    thread_id = os.getenv(CODEX_THREAD_ENV)
+    if thread_id:
+        return thread_id, CODEX_THREAD_ENV
+    return "local-shell", "fallback"
+
+
+def session_key(args: argparse.Namespace, namespace: str) -> str:
+    target_key = args.session_name or f"{args.user}@{args.host}:{args.port}"
+    return f"{namespace}::{target_key}"
+
+
+def session_paths(args: argparse.Namespace) -> tuple[Path, Path, str, str, str]:
+    root = Path(args.session_root).expanduser() if args.session_root else default_session_root()
+    root.mkdir(parents=True, exist_ok=True)
+    os.chmod(root, 0o700)
+    namespace, namespace_source = resolve_session_namespace(args)
+    key = session_key(args, namespace)
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+    return root / f"{digest}.sock", root / f"{digest}.json", key, namespace, namespace_source
+
+
+def target(args: argparse.Namespace) -> str:
+    return f"{args.user}@{args.host}"
+
+
+def base_ssh_command(args: argparse.Namespace, socket_path: Path | None = None) -> list[str]:
+    command = [
         "ssh",
         "-o",
         f"StrictHostKeyChecking={args.strict_host_key_checking}",
@@ -91,39 +214,285 @@ def main() -> int:
         "-p",
         str(args.port),
     ]
+    if socket_path is not None:
+        command.extend(
+            [
+                "-o",
+                "ControlMaster=auto",
+                "-o",
+                "ControlPersist=yes",
+                "-o",
+                f"ControlPath={socket_path}",
+            ]
+        )
     if args.known_hosts_file:
-        ssh_command.extend(["-o", f"UserKnownHostsFile={Path(args.known_hosts_file).expanduser()}"])
-    ssh_command.extend([f"{args.user}@{args.host}", args.remote_command])
+        command.extend(["-o", f"UserKnownHostsFile={Path(args.known_hosts_file).expanduser()}"])
+    return command
 
+
+def check_master_session(args: argparse.Namespace, socket_path: Path) -> tuple[bool, str, str, str]:
+    if not socket_path.exists():
+        return False, "missing", "", ""
+    command = base_ssh_command(args, socket_path) + ["-O", "check", target(args)]
+    completed = subprocess.run(command, capture_output=True, text=True)
+    if completed.returncode == 0:
+        return True, "active", completed.stdout, completed.stderr
+    return False, "stale", completed.stdout, completed.stderr
+
+
+def write_session_metadata(meta_path: Path, args: argparse.Namespace, socket_path: Path, key: str, namespace: str, namespace_source: str) -> None:
+    old_created = None
+    if meta_path.exists():
+        try:
+            old_created = json.loads(meta_path.read_text(encoding="utf-8")).get("created_at")
+        except Exception:
+            old_created = None
+    now = time.time()
+    payload = {
+        "session_name": key,
+        "thread_scope": "current_thread",
+        "thread_id": namespace,
+        "thread_id_source": namespace_source,
+        "user": args.user,
+        "host": args.host,
+        "port": args.port,
+        "socket_path": str(socket_path),
+        "created_at": old_created or now,
+        "last_used_at": now,
+    }
+    meta_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.chmod(meta_path, 0o600)
+
+
+def touch_session_metadata(meta_path: Path, args: argparse.Namespace, socket_path: Path, key: str, namespace: str, namespace_source: str) -> None:
+    write_session_metadata(meta_path, args, socket_path, key, namespace, namespace_source)
+
+
+def cleanup_session_files(socket_path: Path, meta_path: Path) -> None:
+    socket_path.unlink(missing_ok=True)
+    meta_path.unlink(missing_ok=True)
+
+
+def emit_session_status(status: str, reason: str, key: str, socket_path: Path, meta_path: Path, namespace: str, namespace_source: str) -> int:
+    payload = {
+        "status": status,
+        "reason": reason,
+        "session": {
+            "session_name": key,
+            "thread_scope": "current_thread",
+            "thread_id": namespace,
+            "thread_id_source": namespace_source,
+            "socket_path": str(socket_path),
+            "metadata_path": str(meta_path),
+            "socket_exists": socket_path.exists(),
+            "metadata_exists": meta_path.exists(),
+        },
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+def run_expect_ssh(password: str, ssh_command: list[str]) -> subprocess.CompletedProcess[str]:
     script_text = build_expect_script(password, ssh_command)
-
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, suffix=".exp") as handle:
         handle.write(script_text)
         script_path = handle.name
-
+    os.chmod(script_path, 0o600)
     try:
-        completed = subprocess.run(
-            ["expect", script_path],
-            capture_output=True,
-            text=True,
-        )
+        return subprocess.run(["expect", script_path], capture_output=True, text=True)
     finally:
         Path(script_path).unlink(missing_ok=True)
 
+
+def run_and_redact(password: str | None, command: list[str], use_expect: bool) -> tuple[subprocess.CompletedProcess[str], str, str]:
+    completed = run_expect_ssh(password or "", command) if use_expect else subprocess.run(command, capture_output=True, text=True)
+    safe_stdout = redact_secret(completed.stdout, password)
+    safe_stderr = redact_secret(completed.stderr, password)
+    return completed, safe_stdout, safe_stderr
+
+
+def emit_blocked_json(reason: str) -> int:
+    print(
+        json.dumps(
+            {
+                "status": "blocked",
+                "reason": reason,
+                "evidence": {
+                    "command": None,
+                    "exit_code": None,
+                    "stdout": "",
+                    "stderr": "",
+                },
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+def bootstrap_session(args: argparse.Namespace, socket_path: Path, meta_path: Path, key: str, namespace: str, namespace_source: str, password: str) -> tuple[bool, dict[str, object]]:
+    bootstrap_command = base_ssh_command(args, socket_path) + [target(args), "true"]
+    completed, safe_stdout, safe_stderr = run_and_redact(password, bootstrap_command, use_expect=True)
+    if completed.returncode != 0:
+        status, reason = classify(completed.returncode, safe_stdout, safe_stderr)
+        cleanup_session_files(socket_path, meta_path)
+        return False, {
+            "status": status,
+            "reason": reason,
+            "phase": "bootstrap",
+            "evidence": {
+                "command": shlex.join(bootstrap_command),
+                "exit_code": completed.returncode,
+                "stdout": safe_stdout.strip(),
+                "stderr": safe_stderr.strip(),
+            },
+        }
+
+    active, state, check_stdout, check_stderr = check_master_session(args, socket_path)
+    if not active:
+        cleanup_session_files(socket_path, meta_path)
+        return False, {
+            "status": "blocked",
+            "reason": f"SSH master session bootstrap did not become active ({state}).",
+            "phase": "bootstrap",
+            "evidence": {
+                "command": shlex.join(bootstrap_command),
+                "exit_code": completed.returncode,
+                "stdout": redact_secret(check_stdout, password).strip(),
+                "stderr": redact_secret(check_stderr, password).strip(),
+            },
+        }
+
+    write_session_metadata(meta_path, args, socket_path, key, namespace, namespace_source)
+    return True, {
+        "status": "ok",
+        "reason": "SSH master session bootstrapped successfully.",
+        "phase": "bootstrap",
+        "evidence": {
+            "command": shlex.join(bootstrap_command),
+            "exit_code": 0,
+            "stdout": safe_stdout.strip(),
+            "stderr": safe_stderr.strip(),
+        },
+    }
+
+
+def main() -> int:
+    args = parse_args()
+
+    if shutil.which("expect") is None:
+        raise SystemExit("expect is required but was not found in PATH")
+    if shutil.which("ssh") is None:
+        raise SystemExit("ssh is required but was not found in PATH")
+
+    auto_reuse = not args.no_reuse_session
+    socket_path, meta_path, key, namespace, namespace_source = session_paths(args)
+
+    if args.check_session:
+        active, state, _, _ = check_master_session(args, socket_path)
+        if args.session_status_json or args.batch_json:
+            return emit_session_status("ok" if active else "blocked", "master session active" if active else f"master session {state}", key, socket_path, meta_path, namespace, namespace_source)
+        print("active" if active else state)
+        return 0 if active else 1
+
+    if args.close_session:
+        active, _, _, _ = check_master_session(args, socket_path)
+        if active:
+            close_command = base_ssh_command(args, socket_path) + ["-O", "exit", target(args)]
+            subprocess.run(close_command, capture_output=True, text=True)
+        cleanup_session_files(socket_path, meta_path)
+        if args.batch_json:
+            return emit_session_status("ok", "master session closed", key, socket_path, meta_path, namespace, namespace_source)
+        print(f"closed session {key}")
+        return 0
+
+    active_session = False
+    if auto_reuse:
+        active_session, state, _, _ = check_master_session(args, socket_path)
+        if not active_session and state == "stale":
+            cleanup_session_files(socket_path, meta_path)
+
+    if auto_reuse and not active_session:
+        try:
+            password = resolve_password(args)
+        except (PromptError, OSError, SystemExit) as exc:
+            if args.batch_json:
+                return emit_blocked_json(str(exc))
+            if isinstance(exc, SystemExit):
+                raise
+            print(str(exc), file=sys.stderr)
+            return 2
+        boot_ok, boot_result = bootstrap_session(args, socket_path, meta_path, key, namespace, namespace_source, password)
+        if not boot_ok:
+            if args.batch_json:
+                print(json.dumps(boot_result, ensure_ascii=False, indent=2))
+                return 0
+            print(boot_result["reason"], file=sys.stderr)
+            stderr = boot_result["evidence"].get("stderr")
+            if stderr:
+                print(stderr, file=sys.stderr)
+            return 1
+        active_session = True
+        if args.ensure_session:
+            if args.batch_json:
+                print(json.dumps(boot_result, ensure_ascii=False, indent=2))
+            else:
+                print(f"session ready: {key}")
+            return 0
+
+    if args.ensure_session:
+        if args.batch_json:
+            return emit_session_status("ok", "master session active", key, socket_path, meta_path, namespace, namespace_source)
+        print(f"session ready: {key}")
+        return 0
+
+    if auto_reuse and not active_session:
+        reason = "No active session for this thread. Bootstrap with --prompt-password or --ensure-session first."
+        if args.batch_json:
+            return emit_blocked_json(reason)
+        print(reason, file=sys.stderr)
+        return 2
+
+    use_expect = not auto_reuse
+    password: str | None = None
+    if use_expect:
+        try:
+            password = resolve_password(args)
+        except (PromptError, OSError, SystemExit) as exc:
+            if args.batch_json:
+                return emit_blocked_json(str(exc))
+            if isinstance(exc, SystemExit):
+                raise
+            print(str(exc), file=sys.stderr)
+            return 2
+
+    ssh_command = base_ssh_command(args, socket_path if auto_reuse else None) + [target(args), args.remote_command]
+    completed, safe_stdout, safe_stderr = run_and_redact(password, ssh_command, use_expect=use_expect)
+
+    if auto_reuse:
+        if completed.returncode == 0:
+            touch_session_metadata(meta_path, args, socket_path, key, namespace, namespace_source)
+        else:
+            active, _, _, _ = check_master_session(args, socket_path)
+            if not active:
+                cleanup_session_files(socket_path, meta_path)
+
     if not args.batch_json:
-        sys.stdout.write(completed.stdout)
-        sys.stderr.write(completed.stderr)
+        sys.stdout.write(safe_stdout)
+        sys.stderr.write(safe_stderr)
         return completed.returncode
 
-    status, reason = classify(completed.returncode, completed.stdout, completed.stderr)
+    status, reason = (classify(completed.returncode, safe_stdout, safe_stderr) if use_expect else classify_command_failure(completed.returncode, safe_stdout, safe_stderr))
     result = {
         "status": status,
         "reason": reason,
+        "phase": "command",
         "evidence": {
             "command": shlex.join(ssh_command),
             "exit_code": completed.returncode,
-            "stdout": completed.stdout.strip(),
-            "stderr": completed.stderr.strip(),
+            "stdout": safe_stdout.strip(),
+            "stderr": safe_stderr.strip(),
         },
     }
     print(json.dumps(result, ensure_ascii=False, indent=2))

--- a/skills/cloud-instance-ops/scripts/preflight.py
+++ b/skills/cloud-instance-ops/scripts/preflight.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Local preflight checks for cloud instance operations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import socket
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+MUTATING_ACTIONS = {"restart", "deploy", "cloud-op", "transfer"}
+SUPPORTED_CLOUDS = {"generic", "aws", "aliyun"}
+SUPPORTED_ACTIONS = {
+    "connect",
+    "transfer",
+    "inspect",
+    "logs",
+    "restart",
+    "deploy",
+    "instance-check",
+    "cloud-op",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Preflight checks for cloud-instance-ops")
+    parser.add_argument("--cloud", required=True, choices=sorted(SUPPORTED_CLOUDS))
+    parser.add_argument("--action", required=True, choices=sorted(SUPPORTED_ACTIONS))
+    parser.add_argument("--host")
+    parser.add_argument("--port", type=int, default=22)
+    parser.add_argument("--user")
+    parser.add_argument("--identity-file")
+    parser.add_argument("--ssh-config")
+    parser.add_argument("--jump-host")
+    parser.add_argument("--profile")
+    parser.add_argument("--region")
+    parser.add_argument("--restrictions", default="")
+    parser.add_argument("--check-port", action="store_true")
+    parser.add_argument("--timeout", type=float, default=3.0)
+    return parser.parse_args()
+
+
+def required_binaries(cloud: str, action: str) -> List[str]:
+    binaries = []
+    if action in {"connect", "inspect", "logs", "restart", "deploy", "transfer"}:
+        binaries.append("ssh")
+    if action in {"transfer", "deploy"}:
+        binaries.append("scp")
+    if cloud == "aws" and action in {"instance-check", "cloud-op"}:
+        binaries.append("aws")
+    if cloud == "aliyun" and action in {"instance-check", "cloud-op"}:
+        binaries.append("aliyun")
+    return binaries
+
+
+def file_status(path_str: str | None) -> Tuple[bool, str | None]:
+    if not path_str:
+        return True, None
+    path = Path(path_str).expanduser()
+    return path.exists(), str(path)
+
+
+def parse_aws_profiles() -> List[str]:
+    profiles = set()
+    for path_str in ("~/.aws/config", "~/.aws/credentials"):
+        path = Path(path_str).expanduser()
+        if not path.exists():
+            continue
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            raw = line.strip()
+            if raw.startswith("[") and raw.endswith("]"):
+                section = raw[1:-1].strip()
+                if section.startswith("profile "):
+                    section = section[len("profile ") :].strip()
+                if section:
+                    profiles.add(section)
+    return sorted(profiles)
+
+
+def parse_aliyun_profiles() -> List[str]:
+    candidates = [Path("~/.aliyun/config.json").expanduser(), Path("~/.aliyun/config.yaml").expanduser()]
+    names = set()
+    for path in candidates:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        names.update(re.findall(r'"name"\s*:\s*"([^"]+)"', text))
+        names.update(re.findall(r"name\s*:\s*([A-Za-z0-9._-]+)", text))
+    return sorted(names)
+
+
+def check_port(host: str, port: int, timeout: float) -> Tuple[bool, str]:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True, "open"
+    except OSError as exc:
+        return False, str(exc)
+
+
+def classify_restrictions(restrictions: List[str], action: str, jump_host: str | None) -> Tuple[str | None, str | None, str | None]:
+    restriction_set = {item.lower() for item in restrictions}
+
+    if restriction_set & {"mfa", "sso", "approval", "captcha"}:
+        trigger = sorted(restriction_set & {"mfa", "sso", "approval", "captcha"})[0]
+        return (
+            "needs_user",
+            f"The workflow requires an interactive {trigger} step.",
+            f"Complete the required {trigger} step, then rerun the operation.",
+        )
+
+    if "read-only" in restriction_set and action in MUTATING_ACTIONS:
+        return (
+            "denied",
+            "The current access level is read-only for a mutating action.",
+            "Ask for the minimum write permission required for this action, then retry.",
+        )
+
+    if restriction_set & {"allowlist", "ip-allowlist", "private-only", "vpn"}:
+        if jump_host:
+            return None, None, None
+        return (
+            "blocked",
+            "The target appears to require an allowlisted path, VPN, or private-network access.",
+            "Connect through the approved bastion/VPN or ask for the current machine to be allowlisted.",
+        )
+
+    if "bastion" in restriction_set and not jump_host:
+        return (
+            "blocked",
+            "A bastion or jump host is required but was not provided.",
+            "Provide the approved bastion/jump host and rerun preflight.",
+        )
+
+    return None, None, None
+
+
+def main() -> int:
+    args = parse_args()
+    evidence: Dict[str, object] = {
+        "cloud": args.cloud,
+        "action": args.action,
+        "paths": {},
+        "binaries": {},
+        "credentials": {},
+        "network": {},
+        "restrictions": [item for item in args.restrictions.split(",") if item],
+    }
+
+    for binary in required_binaries(args.cloud, args.action):
+        evidence["binaries"][binary] = shutil.which(binary) is not None
+
+    missing_binaries = [name for name, ok in evidence["binaries"].items() if not ok]
+    if missing_binaries:
+        result = {
+            "status": "unsupported",
+            "reason": f"Missing required local binaries: {', '.join(sorted(missing_binaries))}.",
+            "next_step": f"Install {', '.join(sorted(missing_binaries))} locally and rerun preflight.",
+            "evidence": evidence,
+        }
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    for label, candidate in (("identity_file", args.identity_file), ("ssh_config", args.ssh_config)):
+        ok, normalized = file_status(candidate)
+        if normalized:
+            evidence["paths"][label] = {"path": normalized, "exists": ok}
+            if not ok:
+                result = {
+                    "status": "blocked",
+                    "reason": f"Referenced file does not exist: {normalized}.",
+                    "next_step": f"Provide a valid {label.replace('_', ' ')} path and rerun preflight.",
+                    "evidence": evidence,
+                }
+                print(json.dumps(result, ensure_ascii=False, indent=2))
+                return 0
+
+    if args.action in {"connect", "inspect", "logs", "restart", "deploy", "transfer"} and not args.host:
+        result = {
+            "status": "blocked",
+            "reason": "A target host is required for SSH-based operations.",
+            "next_step": "Provide the host or IP address and rerun preflight.",
+            "evidence": evidence,
+        }
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    restrictions = [item.strip() for item in args.restrictions.split(",") if item.strip()]
+    status, reason, next_step = classify_restrictions(restrictions, args.action, args.jump_host)
+    if status:
+        result = {"status": status, "reason": reason, "next_step": next_step, "evidence": evidence}
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    if args.cloud == "aws":
+        aws_profiles = parse_aws_profiles()
+        aws_env = [name for name in ("AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_SESSION_TOKEN") if os.getenv(name)]
+        evidence["credentials"]["aws_profiles"] = aws_profiles
+        evidence["credentials"]["aws_env"] = aws_env
+        if args.profile and args.profile not in aws_profiles and os.getenv("AWS_PROFILE") != args.profile:
+            result = {
+                "status": "needs_user",
+                "reason": f"AWS profile '{args.profile}' was not found in local config or active environment.",
+                "next_step": "Run the approved AWS login/profile setup flow, then retry.",
+                "evidence": evidence,
+            }
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+        if not aws_profiles and not aws_env:
+            result = {
+                "status": "needs_user",
+                "reason": "No obvious AWS credential source was found locally.",
+                "next_step": "Activate an AWS profile or export approved AWS credentials, then rerun preflight.",
+                "evidence": evidence,
+            }
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+    if args.cloud == "aliyun":
+        aliyun_profiles = parse_aliyun_profiles()
+        aliyun_env = [
+            name
+            for name in (
+                "ALIBABA_CLOUD_ACCESS_KEY_ID",
+                "ALIBABA_CLOUD_ACCESS_KEY_SECRET",
+                "ALICLOUD_PROFILE",
+                "ALIYUN_PROFILE",
+            )
+            if os.getenv(name)
+        ]
+        evidence["credentials"]["aliyun_profiles"] = aliyun_profiles
+        evidence["credentials"]["aliyun_env"] = aliyun_env
+        if args.profile and args.profile not in aliyun_profiles and os.getenv("ALICLOUD_PROFILE") != args.profile and os.getenv("ALIYUN_PROFILE") != args.profile:
+            result = {
+                "status": "needs_user",
+                "reason": f"Aliyun profile '{args.profile}' was not found in local config or active environment.",
+                "next_step": "Run the approved Aliyun login/profile setup flow, then retry.",
+                "evidence": evidence,
+            }
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+        if not aliyun_profiles and not aliyun_env:
+            result = {
+                "status": "needs_user",
+                "reason": "No obvious Aliyun credential source was found locally.",
+                "next_step": "Activate an Aliyun profile or export approved credentials, then rerun preflight.",
+                "evidence": evidence,
+            }
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+    if args.check_port and args.host:
+        ok, details = check_port(args.host, args.port, args.timeout)
+        evidence["network"][f"{args.host}:{args.port}"] = "open" if ok else details
+        if not ok:
+            result = {
+                "status": "blocked",
+                "reason": f"Target port {args.port} on {args.host} is not reachable from the current machine.",
+                "next_step": "Use the approved bastion/VPN path or verify that the host and port are reachable from here.",
+                "evidence": evidence,
+            }
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+    if args.jump_host and args.check_port:
+        ok, details = check_port(args.jump_host, args.port, args.timeout)
+        evidence["network"][f"{args.jump_host}:{args.port}"] = "open" if ok else details
+        if not ok:
+            result = {
+                "status": "blocked",
+                "reason": f"Jump host port {args.port} on {args.jump_host} is not reachable from the current machine.",
+                "next_step": "Verify the bastion hostname, network path, and allowlist/VPN requirements, then retry.",
+                "evidence": evidence,
+            }
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+    result = {
+        "status": "ok",
+        "reason": "Local preflight checks passed.",
+        "next_step": "Proceed with the smallest read-only or requested command.",
+        "evidence": evidence,
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/cloud-instance-ops/scripts/remote_port_owner.py
+++ b/skills/cloud-instance-ops/scripts/remote_port_owner.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Inspect which local process owns a listening port."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+
+
+def run_cmd(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inspect which process owns a local port")
+    parser.add_argument('--port', type=int, required=True)
+    args = parser.parse_args()
+
+    evidence = {'port': args.port, 'tool': None, 'matches': []}
+
+    if shutil.which('ss'):
+        cp = run_cmd(['ss', '-tulpn'])
+        evidence['tool'] = 'ss'
+        for line in cp.stdout.splitlines():
+            if f':{args.port} ' in line or line.rstrip().endswith(f':{args.port}'):
+                evidence['matches'].append(line.strip())
+    elif shutil.which('lsof'):
+        cp = run_cmd(['lsof', f'-i:{args.port}', '-nP'])
+        evidence['tool'] = 'lsof'
+        evidence['matches'] = [line.strip() for line in cp.stdout.splitlines()[1:]]
+    else:
+        print(json.dumps({
+            'status': 'unsupported',
+            'reason': 'Neither ss nor lsof is available locally.',
+            'next_step': 'Install ss or lsof, then rerun the port owner check.',
+            'evidence': evidence,
+        }, ensure_ascii=False, indent=2))
+        return 0
+
+    if evidence['matches']:
+        print(json.dumps({
+            'status': 'ok',
+            'reason': f'Found listeners for port {args.port}.',
+            'next_step': 'Inspect the owning process before starting another service on the same port.',
+            'evidence': evidence,
+        }, ensure_ascii=False, indent=2))
+    else:
+        print(json.dumps({
+            'status': 'ok',
+            'reason': f'No listener was found on port {args.port}.',
+            'next_step': 'The port appears free for the next task.',
+            'evidence': evidence,
+        }, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/skills/cloud-instance-ops/scripts/ssh_probe.py
+++ b/skills/cloud-instance-ops/scripts/ssh_probe.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Non-destructive SSH connectivity/auth probe."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+
+
+def classify(exit_code: int, stdout: str, stderr: str) -> tuple[str, str, str]:
+    text = f"{stdout}\n{stderr}".lower()
+    if exit_code == 0:
+        return "ok", "SSH probe succeeded.", "Proceed with the requested remote command."
+    if any(token in text for token in ("mfa", "multi-factor", "verification code", "sso login", "approval")):
+        return "needs_user", "SSH access requires an interactive login or approval step.", "Complete the required interactive access step, then retry."
+    if any(token in text for token in ("permission denied", "publickey", "host key verification failed", "sign_and_send_pubkey")):
+        return "blocked", "SSH authentication failed with the current key, agent, or known_hosts state.", "Provide the correct key/agent/known_hosts path or use the approved bastion flow, then retry."
+    if any(token in text for token in ("operation timed out", "connection timed out", "no route to host", "connection refused", "could not resolve hostname")):
+        return "blocked", "The current machine cannot reach the SSH endpoint.", "Verify host, port, bastion, VPN, or allowlist requirements, then retry."
+    return "blocked", "SSH probe failed.", "Inspect stderr, fix the access path, and retry the probe."
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Non-destructive SSH probe")
+    parser.add_argument("--host", required=True)
+    parser.add_argument("--user")
+    parser.add_argument("--port", type=int, default=22)
+    parser.add_argument("--identity-file")
+    parser.add_argument("--ssh-config")
+    parser.add_argument("--jump-host")
+    parser.add_argument("--timeout", type=int, default=8)
+    parser.add_argument("--remote-command", default="true")
+    args = parser.parse_args()
+
+    target = f"{args.user}@{args.host}" if args.user else args.host
+    command = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        f"ConnectTimeout={args.timeout}",
+        "-p",
+        str(args.port),
+    ]
+
+    if args.ssh_config:
+        command.extend(["-F", str(Path(args.ssh_config).expanduser())])
+    if args.identity_file:
+        command.extend(["-i", str(Path(args.identity_file).expanduser())])
+    if args.jump_host:
+        command.extend(["-J", args.jump_host])
+
+    command.extend([target, args.remote_command])
+
+    try:
+        completed = subprocess.run(command, capture_output=True, text=True, timeout=args.timeout + 2)
+        status, reason, next_step = classify(completed.returncode, completed.stdout, completed.stderr)
+        result = {
+            "status": status,
+            "reason": reason,
+            "next_step": next_step,
+            "evidence": {
+                "command": shlex.join(command),
+                "exit_code": completed.returncode,
+                "stdout": completed.stdout.strip(),
+                "stderr": completed.stderr.strip(),
+            },
+        }
+    except subprocess.TimeoutExpired:
+        result = {
+            "status": "blocked",
+            "reason": "SSH probe timed out.",
+            "next_step": "Verify host reachability, bastion/VPN path, and allowlist rules, then retry.",
+            "evidence": {"command": shlex.join(command), "timeout_seconds": args.timeout + 2},
+        }
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更信息

- PR 类型: `业务同学提交到 dev`
- 目标分支: `dev`
- 源分支: `feat/cloud-instance-ops`
- 涉及 Skill 列表: （仅发布 PR 填写）
- Skill 名称: `cloud-instance-ops`
- Skill 路径: `skills/cloud-instance-ops`
- 业务场景: `云实例访问诊断与 SSH/CLI 运维，按需扩展到显式请求的部署验收与云侧操作`
- 分支名: `feat/cloud-instance-ops`
- 本次是否由 Agent 辅助提交: `是`

## 本次变更内容

- 新增 `skills/cloud-instance-ops/` Skill 目录
- 提供云实例访问诊断与 SSH/CLI 运维主说明 `SKILL.md`
- 补充 AWS / 阿里云 / 通用 Linux / 受限访问 / 部署验收 / 中断恢复等参考资料
- 附带本地预检、SSH 探测、端口占用检查、产物校验和部署最终检查脚本
- 根据 review 建议收窄 Skill 触发边界，并补充 `ok` 场景的最小输出 contract

## 验证方式

- 运行 `python3 scripts/validate_pr_submission.py local --base-ref origin/dev`，本地校验通过
- 运行 `python3 -m py_compile skills/cloud-instance-ops/scripts/*.py`，Python 脚本语法检查通过
- 确认本次改动仅落在 `skills/cloud-instance-ops/` 目录下

## 补充说明

- 本 PR 基于上游最新 `dev` 重新创建
- 已按仓库最新规则使用不含个人信息的分支名与 PR 模板

## Agent 提交备注

- 业务同学提交时，PR 目标分支必须是 `dev`
- 助教发布时，只允许从 `dev` 提 PR 到 `main`
- 公开仓库中不要填写任何个人身份信息
