### PR TITLE
[skill] add hubei-ai-ecosystem-lead-scout

### DIFF
--- a/skills/hubei-ai-ecosystem-lead-scout/SKILL.md
+++ b/skills/hubei-ai-ecosystem-lead-scout/SKILL.md
@@ -161,6 +161,92 @@ Recommended command:
 python3 scripts/build_lead_template.py --input raw_enterprises.txt --output-dir ./out
 ```
 
+
+## Sample Input And Output
+
+Use this section to understand the expected script input, generated spreadsheet shape, and analysis output style before first use.
+
+### Sample input: plain text enterprise list
+
+Create a `.txt` file with one enterprise name per line. Duplicate names are removed while preserving the first occurrence.
+
+```text
+武汉示例智能制造有限公司
+湖北示例医药科技集团
+武汉示例智能制造有限公司
+```
+
+Run:
+
+```bash
+python3 scripts/build_lead_template.py \
+  --input sample_enterprises.txt \
+  --output-dir ./out \
+  --source-label 政府重点企业名单 \
+  --status 新增
+```
+
+Generated files:
+- `out/hubei_ai_leads_template.csv`
+- `out/hubei_ai_leads_template.xlsx`
+
+Sample CSV output preview:
+
+```csv
+企业名称,所在城市,行业,核心产品/业务,企业规模,技术/研发情况,近期动态,AI需求判断,潜在应用场景,线索来源,分类结果,跟进建议,当前状态,更新时间
+武汉示例智能制造有限公司,,,,,,,,,政府重点企业名单,,,新增,
+湖北示例医药科技集团,,,,,,,,,政府重点企业名单,,,新增,
+```
+
+Field meaning in this sample:
+- `企业名称`: filled from the raw input list
+- `线索来源`: filled from `--source-label`
+- `当前状态`: filled from `--status`
+- other fields: intentionally left blank for a later research or enrichment agent to complete
+
+### Sample input: CSV enterprise list
+
+The script can read a CSV with a company-name column. Supported column names include `企业名称`, `公司名称`, `名称`, `company`, `company_name`, and `name`.
+
+```csv
+企业名称,所在城市,行业
+武汉示例光电科技股份有限公司,武汉,光电子
+宜昌示例化工集团有限公司,宜昌,先进材料
+```
+
+Run:
+
+```bash
+python3 scripts/build_lead_template.py --input sample_enterprises.csv --output-dir ./out
+```
+
+### Sample output: single enterprise analysis
+
+When an agent enriches one enterprise after public research, use this style. Keep the judgment concise, evidence-based, and decision-oriented.
+
+```markdown
+企业名称：武汉示例光电科技股份有限公司
+所在城市：武汉
+行业：光电子/智能制造
+核心产品/业务：光电器件、检测设备、智能产线相关产品
+技术/研发情况：公开信息显示企业设有研发团队，并持续发布技术升级和产线改造动态
+近期动态：近期企业公众号提到数字化产线升级、工业视觉检测和智能制造示范项目
+AI需求判断：存在潜在 AI 需求，重点在工业视觉、质检和生产数据分析
+潜在应用场景：视觉缺陷检测、设备预测性维护、工艺参数分析、员工 AI 应用培训
+分类结果：生态伙伴
+跟进建议：建议邀请参加 AI+制造技术交流，进一步确认研发团队和具体试点场景
+```
+
+### Sample output: batch screening table
+
+For batch screening, return a compact table and avoid long company profiles.
+
+| 企业名称 | 所在城市 | 行业 | AI需求判断 | 潜在应用场景 | 分类结果 | 跟进建议 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 武汉示例光电科技股份有限公司 | 武汉 | 光电子/智能制造 | 存在潜在需求 | 视觉质检、设备运维、数据分析 | 生态伙伴 | 建议技术交流 |
+| 湖北示例医药科技集团 | 宜昌 | 医药健康 | 待观察 | 研发知识库、文献分析、培训赋能 | 生态伙伴 | 建议先观察交流 |
+| 武汉示例商贸有限公司 | 武汉 | 商贸服务 | 暂未发现明显需求 | 暂无明确场景 | 暂不跟进 | 暂不投入重点资源 |
+
 ## Reusable Prompt Templates
 
 Use these prompts when another agent needs to call this skill with stable output expectations.

--- a/skills/hubei-ai-ecosystem-lead-scout/SKILL.md
+++ b/skills/hubei-ai-ecosystem-lead-scout/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: hubei-ai-ecosystem-lead-scout
+description: Use this skill when the task is to discover, analyze, classify, or structure Hubei or Wuhan enterprise leads for AI ecosystem cooperation. Apply it for enterprise clue collection, AI demand judgment, partner prioritization, lead-table normalization, or SOP-driven screening tied to Baidu PaddlePaddle, regional AI enablement, technical exchange, training, or ecosystem partnership building.
+---
+
+# Hubei AI Ecosystem Lead Scout
+
+## Overview
+
+This skill standardizes how to collect and judge enterprise leads in Hubei for AI ecosystem cooperation. It is built for regional ecosystem operations rather than pure sales prospecting, so the core output is a judgment on AI demand, scene fit, and partnership potential.
+
+Use this skill when you need to:
+- find Hubei or Wuhan enterprises worth researching
+- analyze whether an enterprise has AI application scenarios
+- judge whether an enterprise is a potential ecosystem partner
+- classify leads as key account, ecosystem partner, technical case, or hold
+- turn messy research notes into a consistent lead sheet or SOP output
+
+If the user provides a raw enterprise list and wants a standard template quickly, use `scripts/build_lead_template.py`.
+
+## Workflow
+
+1. Confirm the task target.
+Determine whether the user needs enterprise discovery, lead analysis, table cleanup, partner classification, or SOP generation.
+
+2. Gather only the minimum enterprise facts first.
+Start with enterprise name, city, industry, core products or business, enterprise scale, and technical or R&D capability if available.
+
+3. Focus on AI-scene evidence, not broad company profiling.
+Check recent public signals such as official news,公众号内容, activity participation, product updates, partner introductions, hiring, and digital transformation messaging.
+
+4. Judge partnership value using the two hard gates.
+An enterprise is a strong candidate only if both are broadly true:
+- it has a plausible AI application scenario
+- it has a technical team or technical carrying capacity
+
+If the scenario is good but the technical team is unclear, do not discard it immediately. Mark it as observation or light-touch communication.
+
+5. Classify the enterprise.
+Use exactly one primary classification:
+- `大客户`: large scale, strong regional influence, demo effect, and clear AI cooperation scenes
+- `生态伙伴`: has AI demand or cooperation basis and can join project, technology, training, activity, or ecosystem collaboration
+- `技术案例`: an outstanding ecosystem partner with representative AI scenarios and external storytelling value
+- `暂不跟进`: no clear AI scene, weak technical basis, insufficient information, unclear timing, or poor fit
+
+6. Produce a structured result.
+When possible, output in a lead-table-ready format using the standard field set below.
+
+7. Normalize raw enterprise lists when needed.
+If the input is only a company-name list, run `python3 scripts/build_lead_template.py --input <file> --output-dir <dir>`. The script creates both CSV and XLSX templates with the standard columns.
+
+## Standard Fields
+
+Use these columns when building or normalizing a lead sheet:
+
+| 字段 | 用途 |
+| --- | --- |
+| 企业名称 | 唯一识别对象 |
+| 所在城市 | 武汉或湖北其他地市 |
+| 行业 | 行业赛道判断 |
+| 核心产品/业务 | 识别业务场景 |
+| 企业规模 | 判断大客户潜力与影响力 |
+| 技术/研发情况 | 判断是否具备技术承接能力 |
+| 近期动态 | 提取公开信号来源 |
+| AI需求判断 | 明确是否存在明确需求、潜在需求、待观察 |
+| 潜在应用场景 | 例如质检、客服、知识库、培训、数据分析 |
+| 线索来源 | 政府名单、官网、公众号、活动名单、伙伴推荐等 |
+| 分类结果 | 大客户、生态伙伴、技术案例、暂不跟进 |
+| 跟进建议 | 建议观察、交流、邀约活动、技术交流等 |
+| 当前状态 | 新增、观察中、已分析、待沟通等 |
+| 更新时间 | 便于周度更新 |
+
+## Classification Details
+
+### 大客户
+
+Use when the enterprise is large, influential, often group-like or leading in its region or industry, has demonstration value, and also shows clear AI cooperation scenes.
+
+### 生态伙伴
+
+Use when the enterprise has AI demand or cooperation willingness, has technical cooperation potential, and can participate in project, technical, training, activity, or ecosystem collaboration.
+
+### 技术案例
+
+Use only for strong ecosystem partners with representative AI application scenes and good external case value.
+
+### 暂不跟进
+
+Use when there is no clear AI scene, no obvious technical basis, insufficient public information, unclear cooperation timing, or weak fit with Baidu AI ecosystem work.
+
+## Quality Threshold
+
+A high-quality lead usually has most of these traits:
+- a credible AI application scene
+- technical or R&D capacity
+- public signals showing intelligent upgrade or innovation direction
+- regional or industry influence
+- potential fit for Baidu AI ecosystem enablement
+
+## Judgment Rules
+
+Prioritize these signals:
+- clear intelligent upgrade, digital transformation, or AI application intent
+- industry scenes suitable for AI, such as knowledge Q&A, visual inspection, customer service, data analysis, training, operations support, or model-based efficiency tools
+- evidence of technical or R&D capability
+- strong regional or industry influence
+- ability to become an activity, training, project, or technical cooperation object
+
+Avoid overvaluing:
+- company size without a usable AI scene
+- generic innovation messaging without concrete business signals
+- contact completeness as a proxy for quality
+
+## Output Style
+
+Keep outputs concise and decision-oriented. For each enterprise, prefer:
+- one-line enterprise summary
+- AI demand judgment
+- potential application scenes
+- classification result
+- short follow-up suggestion
+
+For one enterprise, prefer this compact structure:
+
+```markdown
+企业名称：
+所在城市：
+行业：
+核心产品/业务：
+技术/研发情况：
+近期动态：
+AI需求判断：
+潜在应用场景：
+分类结果：
+跟进建议：
+```
+
+If the user asks for batch analysis, use a compact table or spreadsheet with the standard fields in this file.
+
+Use `scripts/build_lead_template.py` when:
+- the user has a plain-text, CSV, TSV, or JSON enterprise list
+- you need to normalize rows before analysis
+- you want a reusable lead sheet for batch enrichment by another agent
+
+## Script Notes
+
+`scripts/build_lead_template.py` turns a raw enterprise list into a standard spreadsheet template.
+
+Supported inputs:
+- `.txt`: one enterprise name per line
+- `.csv` or `.tsv`: first column or a detected `企业名称` or `company` style column
+- `.json`: a list of strings or objects containing a company-name field
+
+Outputs:
+- `hubei_ai_leads_template.csv`
+- `hubei_ai_leads_template.xlsx`
+
+Recommended command:
+
+```bash
+python3 scripts/build_lead_template.py --input raw_enterprises.txt --output-dir ./out
+```
+
+## Reusable Prompt Templates
+
+Use these prompts when another agent needs to call this skill with stable output expectations.
+
+### Single Enterprise Analysis
+
+```text
+Use $hubei-ai-ecosystem-lead-scout to analyze this enterprise for Hubei AI ecosystem cooperation.
+Focus on whether it has a credible AI application scenario, whether it has technical or R&D capacity, what cooperation direction is most plausible, and which one classification fits best.
+Output with these fields:
+企业名称
+所在城市
+行业
+核心产品/业务
+技术/研发情况
+近期动态
+AI需求判断
+潜在应用场景
+分类结果
+跟进建议
+```
+
+### Batch Enterprise Screening
+
+```text
+Use $hubei-ai-ecosystem-lead-scout to screen this batch of Hubei or Wuhan enterprises for AI ecosystem partnership potential.
+For each enterprise, judge AI demand, infer possible application scenes from public signals, and classify it as 大客户、生态伙伴、技术案例、暂不跟进.
+Return the result as a compact table using the standard fields in this skill.
+```
+
+### Lead Sheet Enrichment
+
+```text
+Use $hubei-ai-ecosystem-lead-scout to enrich this enterprise lead sheet.
+Do not rewrite the whole table. Fill missing fields where the public information is sufficient, especially:
+技术/研发情况
+近期动态
+AI需求判断
+潜在应用场景
+分类结果
+跟进建议
+Keep judgments concise and decision-oriented.
+```
+
+### Activity Or Training Target Selection
+
+```text
+Use $hubei-ai-ecosystem-lead-scout to identify which enterprises are best suited for AI technical exchange, training, or regional ecosystem activity invitation.
+Prioritize enterprises with clear scenarios, technical carrying capacity, and regional influence.
+For each recommended enterprise, explain the most suitable cooperation entry point in one sentence.
+```
+
+## Collaboration Notes
+
+When this skill is used with other agents or tools:
+- use the script first if the input is only a raw company list
+- use web research second to gather recent public signals
+- apply classification only after checking both AI scene plausibility and technical capacity
+- prefer concise judgments over long company profiles
+- keep one primary classification per enterprise unless the user explicitly asks for multi-tagging
+
+## Guardrails
+
+- Do not classify a company as high priority based only on size or fame.
+- Do not infer strong AI demand without at least one business-scene signal.
+- If evidence is weak, mark the lead as observation-oriented rather than overcommitting.
+- If the company has strong scenes but unclear technical team, keep it in observation or light-touch communication instead of discarding it.
+- For this skill, partnership value matters more than contact completeness.

--- a/skills/hubei-ai-ecosystem-lead-scout/scripts/build_lead_template.py
+++ b/skills/hubei-ai-ecosystem-lead-scout/scripts/build_lead_template.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Build a standard Hubei AI ecosystem lead template from a raw enterprise list."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+from zipfile import ZIP_DEFLATED, ZipFile
+from xml.sax.saxutils import escape
+
+
+HEADERS = [
+    "企业名称",
+    "所在城市",
+    "行业",
+    "核心产品/业务",
+    "企业规模",
+    "技术/研发情况",
+    "近期动态",
+    "AI需求判断",
+    "潜在应用场景",
+    "线索来源",
+    "分类结果",
+    "跟进建议",
+    "当前状态",
+    "更新时间",
+]
+
+COMPANY_KEYS = [
+    "企业名称",
+    "公司名称",
+    "名称",
+    "company",
+    "company_name",
+    "name",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert a raw enterprise list into standard CSV/XLSX lead templates."
+    )
+    parser.add_argument("--input", required=True, help="Path to txt/csv/tsv/json input.")
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="Directory for generated files. Defaults to current directory.",
+    )
+    parser.add_argument(
+        "--source-label",
+        default="待补充",
+        help="Default value for the 线索来源 column.",
+    )
+    parser.add_argument(
+        "--status",
+        default="新增",
+        help="Default value for the 当前状态 column.",
+    )
+    return parser.parse_args()
+
+
+def normalize_name(raw: str) -> str:
+    return " ".join(raw.strip().split())
+
+
+def dedupe_keep_order(names: Iterable[str]) -> list[str]:
+    seen = set()
+    result = []
+    for name in names:
+        normalized = normalize_name(name)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def detect_company_key(row: dict) -> str | None:
+    lowered = {str(key).strip().lower(): key for key in row.keys()}
+    for candidate in COMPANY_KEYS:
+        if candidate in row:
+            return candidate
+        key = lowered.get(candidate.lower())
+        if key is not None:
+            return key
+    return None
+
+
+def load_names(path: Path) -> list[str]:
+    suffix = path.suffix.lower()
+    if suffix == ".txt":
+        return dedupe_keep_order(path.read_text(encoding="utf-8").splitlines())
+    if suffix in {".csv", ".tsv"}:
+        delimiter = "," if suffix == ".csv" else "\t"
+        with path.open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = csv.DictReader(handle, delimiter=delimiter)
+            if reader.fieldnames:
+                names = []
+                for row in reader:
+                    key = detect_company_key(row)
+                    if key is None and reader.fieldnames:
+                        first_key = reader.fieldnames[0]
+                        value = row.get(first_key, "")
+                    else:
+                        value = row.get(key or "", "")
+                    names.append(value)
+                return dedupe_keep_order(names)
+        with path.open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = csv.reader(handle, delimiter=delimiter)
+            return dedupe_keep_order(row[0] for row in reader if row)
+    if suffix == ".json":
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            raise ValueError("JSON input must be a list.")
+        names = []
+        for item in data:
+            if isinstance(item, str):
+                names.append(item)
+                continue
+            if isinstance(item, dict):
+                key = detect_company_key(item)
+                if key is not None:
+                    names.append(str(item.get(key, "")))
+                    continue
+            raise ValueError("JSON list items must be strings or objects with a company-name field.")
+        return dedupe_keep_order(names)
+    raise ValueError(f"Unsupported input format: {suffix}")
+
+
+def build_rows(names: list[str], source_label: str, status: str) -> list[list[str]]:
+    rows = []
+    for name in names:
+        row = [""] * len(HEADERS)
+        row[0] = name
+        row[9] = source_label
+        row[12] = status
+        rows.append(row)
+    return rows
+
+
+def write_csv(path: Path, rows: list[list[str]]) -> None:
+    with path.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(HEADERS)
+        writer.writerows(rows)
+
+
+def col_name(index: int) -> str:
+    name = ""
+    while index > 0:
+        index, rem = divmod(index - 1, 26)
+        name = chr(65 + rem) + name
+    return name
+
+
+def worksheet_xml(rows: list[list[str]]) -> str:
+    header_cells = []
+    for idx, value in enumerate(HEADERS, start=1):
+        cell_ref = f"{col_name(idx)}1"
+        header_cells.append(inline_str_cell(cell_ref, value))
+
+    body_rows = []
+    for row_idx, row in enumerate(rows, start=2):
+        cells = []
+        for col_idx, value in enumerate(row, start=1):
+            if value == "":
+                continue
+            cells.append(inline_str_cell(f"{col_name(col_idx)}{row_idx}", value))
+        body_rows.append(f'<row r="{row_idx}">{"".join(cells)}</row>')
+
+    dimension = f"A1:{col_name(len(HEADERS))}{max(1, len(rows) + 1)}"
+    cols_xml = (
+        "<cols>"
+        '<col min="1" max="1" width="28" customWidth="1"/>'
+        '<col min="2" max="4" width="18" customWidth="1"/>'
+        '<col min="5" max="6" width="16" customWidth="1"/>'
+        '<col min="7" max="14" width="24" customWidth="1"/>'
+        "</cols>"
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        f"<dimension ref=\"{dimension}\"/>"
+        '<sheetViews><sheetView workbookViewId="0"/></sheetViews>'
+        "<sheetFormatPr defaultRowHeight=\"15\"/>"
+        f"{cols_xml}"
+        "<sheetData>"
+        f'<row r="1">{"".join(header_cells)}</row>'
+        f'{"".join(body_rows)}'
+        "</sheetData>"
+        "</worksheet>"
+    )
+
+
+def inline_str_cell(ref: str, value: str) -> str:
+    return (
+        f'<c r="{ref}" t="inlineStr"><is><t>{escape(value)}</t></is></c>'
+    )
+
+
+def write_xlsx(path: Path, rows: list[list[str]]) -> None:
+    content_types = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
+  <Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>
+</Types>
+"""
+    root_rels = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml"/>
+</Relationships>
+"""
+    workbook = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="企业线索模板" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>
+"""
+    workbook_rels = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>
+"""
+    app_xml = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
+  <Application>Codex</Application>
+</Properties>
+"""
+    core_xml = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dc:creator>Codex</dc:creator>
+  <cp:lastModifiedBy>Codex</cp:lastModifiedBy>
+</cp:coreProperties>
+"""
+
+    with ZipFile(path, "w", compression=ZIP_DEFLATED) as zf:
+        zf.writestr("[Content_Types].xml", content_types)
+        zf.writestr("_rels/.rels", root_rels)
+        zf.writestr("xl/workbook.xml", workbook)
+        zf.writestr("xl/_rels/workbook.xml.rels", workbook_rels)
+        zf.writestr("xl/worksheets/sheet1.xml", worksheet_xml(rows))
+        zf.writestr("docProps/app.xml", app_xml)
+        zf.writestr("docProps/core.xml", core_xml)
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_dir = Path(args.output_dir).expanduser().resolve()
+
+    if not input_path.exists():
+        print(f"Input file not found: {input_path}", file=sys.stderr)
+        return 1
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        names = load_names(input_path)
+    except Exception as exc:
+        print(f"Failed to read input: {exc}", file=sys.stderr)
+        return 1
+
+    if not names:
+        print("No enterprise names found in input.", file=sys.stderr)
+        return 1
+
+    rows = build_rows(names, args.source_label, args.status)
+    csv_path = output_dir / "hubei_ai_leads_template.csv"
+    xlsx_path = output_dir / "hubei_ai_leads_template.xlsx"
+    write_csv(csv_path, rows)
+    write_xlsx(xlsx_path, rows)
+
+    print(f"Generated {len(rows)} rows.")
+    print(f"CSV: {csv_path}")
+    print(f"XLSX: {xlsx_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/hubei-ai-ecosystem-lead-scout/scripts/build_lead_template.py
+++ b/skills/hubei-ai-ecosystem-lead-scout/scripts/build_lead_template.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import io
 import json
 import sys
 from pathlib import Path
@@ -38,6 +39,8 @@ COMPANY_KEYS = [
     "company_name",
     "name",
 ]
+
+COMPANY_KEYS_LOWER = {key.lower() for key in COMPANY_KEYS}
 
 
 def parse_args() -> argparse.Namespace:
@@ -90,28 +93,42 @@ def detect_company_key(row: dict) -> str | None:
     return None
 
 
+def row_looks_like_header(first_row: list[str], sample_text: str) -> bool:
+    normalized = [cell.strip().lower() for cell in first_row if cell.strip()]
+    if any(cell in COMPANY_KEYS_LOWER for cell in normalized):
+        return True
+    try:
+        return csv.Sniffer().has_header(sample_text)
+    except csv.Error:
+        return False
+
+
 def load_names(path: Path) -> list[str]:
     suffix = path.suffix.lower()
     if suffix == ".txt":
         return dedupe_keep_order(path.read_text(encoding="utf-8").splitlines())
     if suffix in {".csv", ".tsv"}:
         delimiter = "," if suffix == ".csv" else "\t"
-        with path.open("r", encoding="utf-8-sig", newline="") as handle:
-            reader = csv.DictReader(handle, delimiter=delimiter)
-            if reader.fieldnames:
-                names = []
-                for row in reader:
-                    key = detect_company_key(row)
-                    if key is None and reader.fieldnames:
-                        first_key = reader.fieldnames[0]
-                        value = row.get(first_key, "")
-                    else:
-                        value = row.get(key or "", "")
-                    names.append(value)
-                return dedupe_keep_order(names)
-        with path.open("r", encoding="utf-8-sig", newline="") as handle:
-            reader = csv.reader(handle, delimiter=delimiter)
-            return dedupe_keep_order(row[0] for row in reader if row)
+        raw_text = path.read_text(encoding="utf-8-sig")
+        rows = list(csv.reader(io.StringIO(raw_text), delimiter=delimiter))
+        non_empty_rows = [row for row in rows if row]
+        if not non_empty_rows:
+            return []
+
+        if row_looks_like_header(non_empty_rows[0], raw_text):
+            reader = csv.DictReader(io.StringIO(raw_text), delimiter=delimiter)
+            names = []
+            for row in reader:
+                key = detect_company_key(row)
+                if key is None and reader.fieldnames:
+                    first_key = reader.fieldnames[0]
+                    value = row.get(first_key, "")
+                else:
+                    value = row.get(key or "", "")
+                names.append(value)
+            return dedupe_keep_order(names)
+
+        return dedupe_keep_order(row[0] for row in non_empty_rows if row)
     if suffix == ".json":
         data = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(data, list):


### PR DESCRIPTION
## 变更信息

- PR 类型: `业务同学提交到 dev`
- 目标分支: `dev`
- 源分支: `feat/hubei-ai-ecosystem-lead-scout`
- 涉及 Skill 列表: 
- Skill 名称: `hubei-ai-ecosystem-lead-scout`
- Skill 路径: `skills/hubei-ai-ecosystem-lead-scout`
- 业务场景: 湖北省及武汉市企业 AI 生态合作线索收集、需求研判、分类和表格整理，适用于区域生态赋能、技术交流、培训合作、活动邀约和潜在合作伙伴筛选。
- 分支名: `feat/hubei-ai-ecosystem-lead-scout`
- 本次是否由 Agent 辅助提交: `是`

## 本次变更内容

- 新增业务 Skill `hubei-ai-ecosystem-lead-scout`
- 补充湖北/武汉企业 AI 生态合作线索筛选、分类和输出规范
- 提供企业名单整理脚本 `scripts/build_lead_template.py`，支持生成标准 CSV/XLSX 模板

## 验证方式

- 检查 Skill 目录位于 `skills/hubei-ai-ecosystem-lead-scout/`
- 检查 `SKILL.md` 包含使用场景、执行流程、输出要求和分类规则
- 运行 `python3 skills/hubei-ai-ecosystem-lead-scout/scripts/build_lead_template.py --help` 验证脚本可执行

## 补充说明

- 该 Skill 聚焦业务场景判断，不以传统销售获客信息完整度为核心，而以 AI 场景、技术承接能力和生态合作潜力为主要判断维度。

## Agent 提交备注

- 业务同学提交时，PR 目标分支必须是 `dev`
- 助教发布时，只允许从 `dev` 提 PR 到 `main`
- 公开仓库中不要填写任何个人身份信息
