### PR TITLE
fix(pr-guard): 检测 PR 描述中的个人身份信息关键词

### DIFF
--- a/scripts/validate_pr_submission.py
+++ b/scripts/validate_pr_submission.py
@@ -285,6 +285,13 @@ def validate_changed_skill_files(
     return skill_dir
 
 
+def check_no_pii(body: str, errors: List[str]) -> None:
+    if "业务同学真实姓名" in body:
+        errors.append(
+            "PR 描述中不得包含个人身份信息（检测到 `业务同学真实姓名` 字样）。请删除后重新提交。"
+        )
+
+
 def require_fields(fields: Dict[str, str], names: List[str], errors: List[str]) -> None:
     for field in names:
         if not fields.get(field):
@@ -446,6 +453,8 @@ def run_pr() -> int:
     files = changed_files(f"origin/{base_ref}")
     errors: List[str] = []
 
+    check_no_pii(body, errors)
+
     if base_ref == "dev":
         if touches_business_skill(files):
             validate_contributor_pr(body, branch, base_ref, files, errors)
@@ -511,6 +520,8 @@ def run_pr_target() -> int:
         return 1
 
     files = [item.get("filename", "") for item in pr_files if item.get("filename")]
+
+    check_no_pii(body, errors)
 
     if base_ref != "dev":
         errors.append("来自 Fork 的 PR 只支持业务 Skill 提交到 `dev`。")


### PR DESCRIPTION
## 变更信息

- PR 类型: `仓库维护提交到 dev`
- 目标分支: dev
- 源分支: fix/pr-guard-pii-check
- 涉及 Skill 列表: （仅发布 PR 填写）
- Skill 名称: （仅业务 Skill PR 填写）
- Skill 路径: （仅业务 Skill PR 填写）
- 业务场景: （仅业务 Skill PR 填写）
- 分支名: fix/pr-guard-pii-check
- 本次是否由 Agent 辅助提交: （仅业务 Skill PR 填写）

## 本次变更内容

- 在 `scripts/validate_pr_submission.py` 中新增 `check_no_pii` 函数
- 若 PR body 中包含个人身份信息关键词，校验立即失败
- 在 `run_pr`（同仓库 PR）和 `run_pr_target`（Fork PR）两个路径中均调用，覆盖所有 PR 类型

## 验证方式

- 在 PR body 中写入受检关键词，运行 `python3 scripts/validate_pr_submission.py pr` 确认报错
- 正常 PR 描述不受影响，校验通过

## 补充说明

- 该检查在具体类型校验（业务/维护/发布）之前执行，确保任何 PR 类型都能触发