### PR TITLE
update: refresh paddleocr-expert version maintenance

### DIFF
--- a/skills/paddleocr-expert/SKILL.md
+++ b/skills/paddleocr-expert/SKILL.md
@@ -54,6 +54,8 @@ Follow this sequence unless the user clearly wants only a narrow answer:
    Read `references/troubleshooting.md` when the user mentions Windows, WSL, vLLM, OOM, timeout, ONNX, serving instability, or bad-case parsing.
 6. If this is customer-facing support, translate the diagnosis into a reply the user can send without editing.
 7. End with a structured follow-up record the operator can paste into a multi-dimensional table.
+8. Treat commands, model names, and pipeline registration names as version-sensitive.
+   If the question depends on "latest", install extras, CLI syntax, or flagship model naming, verify against the current official docs before answering.
 
 ## Default Recommendations
 
@@ -91,6 +93,30 @@ Read only what is needed:
   Use for current issue patterns, version alignment, Windows/WSL caveats, vLLM limits, concurrency expectations, and likely failure modes.
 - `references/customer-followup.md`
   Use when the user wants a direct customer reply, a CRM-style follow-up summary, or a multi-dimensional table row.
+- `references/version-maintenance.md`
+  Use when the answer depends on the latest command syntax, package extras, model naming, pipeline registration names, or when the skill itself needs periodic refresh.
+
+## Version Maintenance
+
+PaddleOCR and PaddleX move quickly. Keep this skill conservative on anything that may drift between minor releases.
+
+Always treat these as version-sensitive:
+
+- package install commands and optional extras
+- CLI subcommands and flags
+- PaddleX pipeline registration names
+- flagship model names such as `PaddleOCR-VL` vs `PaddleOCR-VL-1.5`
+- Windows, CUDA, and backend compatibility notes
+
+Before giving a customer-facing or implementation-facing answer on those topics:
+
+1. Check the current official docs or repo pages.
+2. Prefer the newest official naming over memory.
+3. State when advice is version-sensitive.
+4. If you cannot verify, say so and avoid overstating certainty.
+
+When maintaining this skill, periodically review the reference files for stale commands or renamed models.
+Prefer a monthly review cadence, and also refresh after major PaddleOCR, PaddleX, or PaddleOCR-VL releases.
 
 ## Customer Support Mode
 

--- a/skills/paddleocr-expert/references/deployment.md
+++ b/skills/paddleocr-expert/references/deployment.md
@@ -54,6 +54,15 @@ python -m pip install "paddleocr[all]"
 - PaddleOCR docs describe the current 3.4.x line as matching PaddleX `>=3.4.0,<3.5.0`.
 - Do not mix arbitrary PaddleOCR, PaddleX, and PaddlePaddle versions when debugging. Check the version trio first.
 
+## Version-Sensitive Commands To Recheck
+
+Re-verify these on every maintenance pass because they are likely to drift:
+
+- install extras such as `paddleocr[doc-parser]`, `paddleocr[ie]`, and `paddleocr[all]`
+- CLI entry points such as `paddleocr doc_parser`
+- PaddleX serving commands and plugin installation flow
+- any example command that names a pipeline directly
+
 ## First Local Validation
 
 Before serving, validate on representative files:

--- a/skills/paddleocr-expert/references/selection.md
+++ b/skills/paddleocr-expert/references/selection.md
@@ -71,6 +71,14 @@ PaddleOCR 3.x docs state that PaddleOCR uses PaddleX underneath for inference an
 | PaddleOCR-VL | `PaddleOCR-VL` |
 | PaddleOCR-VL-1.5 | `PaddleOCR-VL-1.5` |
 
+## Version-Sensitive Names To Recheck
+
+Re-verify these during maintenance because naming can shift with new releases:
+
+- flagship VLM names such as `PaddleOCR-VL` and `PaddleOCR-VL-1.5`
+- PaddleX registration names used by `paddlex --serve`
+- whether a capability is positioned as a pipeline, model family, or package extra in the latest docs
+
 ## Common Recommendation Patterns
 
 - Existing `/ocr` API, wants table parsing too:

--- a/skills/paddleocr-expert/references/version-maintenance.md
+++ b/skills/paddleocr-expert/references/version-maintenance.md
@@ -1,0 +1,47 @@
+# Version Maintenance
+
+Last reviewed: April 21, 2026.
+
+Use this file when:
+
+- the user asks for the latest PaddleOCR or PaddleX usage,
+- the answer depends on exact commands or package extras,
+- model naming may have changed,
+- or you are maintaining this skill after review feedback.
+
+## High-Risk Drift Areas
+
+Check these first because they change fastest:
+
+1. package install groups such as `paddleocr`, `paddleocr[doc-parser]`, `paddleocr[ie]`, and `paddleocr[all]`
+2. CLI entry points such as `paddlex --serve`, `paddlex --get_pipeline_config`, and `paddleocr doc_parser`
+3. PaddleX pipeline registration names such as `OCR`, `table_recognition_v2`, `PP-StructureV3`, `PP-ChatOCRv4-doc`, and `PaddleOCR-VL(-1.5)`
+4. flagship model naming on docs home pages and model cards
+5. hardware and backend caveats for Windows, WSL, CUDA, `vLLM`, and high-performance serving
+
+## Maintenance Checklist
+
+For each review pass:
+
+1. confirm the "Last reviewed" date in each reference file
+2. verify install commands against the current official docs
+3. verify model and pipeline names against the current official docs
+4. verify any hardware caveats that could have changed with new releases
+5. update wording where the old answer sounds more certain than the docs support
+
+## Minimum Files To Recheck
+
+- `references/deployment.md`
+- `references/selection.md`
+- `references/troubleshooting.md`
+
+These files contain the most version-sensitive commands and names.
+
+## Answering Rule
+
+When the user asks a time-sensitive question, do not answer from memory alone.
+Re-check the official source first, then answer with clear wording such as:
+
+- "As of April 21, 2026, the docs show ..."
+- "This is version-sensitive; the current docs list ..."
+- "I did not find an official retention guarantee, so treat it as temporary."


### PR DESCRIPTION
﻿## 变更信息

- PR 类型: 业务同学提交到 dev
- 目标分支: dev
- 源分支: update/paddleocr-expert
- 涉及 Skill 列表: 无
- Skill 名称: paddleocr-expert
- Skill 路径: skills/paddleocr-expert
- 业务场景: 同步 paddleocr-expert 的后续维护更新，补充 PaddleOCR / PaddleX 版本敏感命令、模型名称和 reference 复查规则，降低因版本变化导致的回答过期风险。
- 分支名: update/paddleocr-expert
- 本次是否由 Agent 辅助提交: 是

## 本次变更内容

- 为 `paddleocr-expert` 增加版本敏感规则
- 新增 `references/version-maintenance.md` 维护清单
- 在部署与选型 reference 中补充需要优先复查的命令和模型名

## 验证方式

- 检查变更仅落在 `skills/paddleocr-expert/`
- 检查分支名与 skill slug 对齐，目标分支为 `dev`
- 检查新增 reference 与 `SKILL.md` 中的入口说明保持一致

## 补充说明

- 本次 PR 是对已合并 skill 的后续维护更新，不涉及其他 skill 目录

## Agent 提交备注

- 已从 `upstream/dev` 拉出独立分支 `update/paddleocr-expert`
- 已同步开源仓库中的版本维护更新，并只提交 `skills/paddleocr-expert/` 相关文件
