### PR TITLE
docs: add skills category catalog

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,21 +1,125 @@
-# Skills 目录说明
+# Skills 分类导航
 
-所有业务 Skill 均收敛在本目录下。
+本目录收录已经合入 `dev` 的业务型 Agent Skills。使用者可以先按业务目标选择分类，再进入对应 Skill 目录阅读 `SKILL.md`、`references/`、`assets/` 或 `scripts/`。
 
-## 推荐结构
+## 如何使用本目录
+
+- 如果你已经知道业务目标，优先从下面的分类索引进入。
+- 如果你只知道关键词，可以在本目录搜索 skill slug、业务词或触发词。
+- 每个正式 Skill 都应有独立目录和 `SKILL.md`；`_template/` 只作为新增 Skill 的写作模板，不是正式 Skill。
+
+## 按场景分类索引
+
+### 行业情报与市场监测
+
+| Skill | 适合做什么 |
+|---|---|
+| [ai-hardware-ecosystem-monitor](./ai-hardware-ecosystem-monitor/) | 监控 AI 硬件、算力基础设施、供应链新闻和风险信号 |
+| [ai-overseas-daily](./ai-overseas-daily/) | 生成海外 AI/LLM 日报、竞争格局和工程前沿情报 |
+| [baidu-paddle-wenxin-operation](./baidu-paddle-wenxin-operation/) | 搜集飞桨、文心、竞品动态、厦门 AI 政策和潜在客户线索 |
+| [community-insight-pipeline](./community-insight-pipeline/) | 从 Reddit 抓取产品或话题讨论，并分析相关性、情感和优劣势 |
+| [datasets-search](./datasets-search/) | 搜索、爬取和汇总开源数据集、企业数据集和高质量数据集动态 |
+| [energy-llm-tracker](./energy-llm-tracker/) | 调研能源行业大模型应用动态、企业进展和落地案例 |
+| [ernie-image-monitor](./ernie-image-monitor/) | 监测中文平台上的 ERNIE-Image 内容、讨论和反馈 |
+| [ernie-monitor](./ernie-monitor/) | 监测文心大模型全网舆情、KOL、竞品进展和用户反馈 |
+| [github-tracker](./github-tracker/) | 跟踪 vLLM、FastDeploy 等技术项目的 GitHub PR 进展 |
+| [llm-data-research](./llm-data-research/) | 监控大模型数据、数据标注、专家招募和数据服务商市场动态 |
+| [wuhan-ai-daily](./wuhan-ai-daily/) | 搜索武汉 AI 政策、新闻和活动信息，并整理到飞书多维表格 |
+
+### 线索、机构与生态伙伴
+
+| Skill | 适合做什么 |
+|---|---|
+| [business-archives-full](./business-archives-full/) | 按固定 SOP 生成完整企业档案 |
+| [company-lookup](./company-lookup/) | 查询和核验中国企业工商主体信息 |
+| [eco-partner-registration](./eco-partner-registration/) | 执行生态产品提报、伙伴协议提报和入库材料准备 |
+| [ecopartner-match-recommend](./ecopartner-match-recommend/) | 根据客户 AI 需求匹配中南片区生态伙伴并生成推荐报告 |
+| [hubei-ai-ecosystem-lead-scout](./hubei-ai-ecosystem-lead-scout/) | 发现、分析和筛选湖北或武汉 AI 生态合作企业线索 |
+| [international-lead-research](./international-lead-research/) | 调研国际化线索、平台、工具和与 PaddleOCR/ERNIE 的合作可能性 |
+| [org-research](./org-research/) | 对政府单位、企事业单位等会谈对象做高可靠背景和业务调研 |
+
+### 售前、方案与客户交付
+
+| Skill | 适合做什么 |
+|---|---|
+| [ai-project-quote](./ai-project-quote/) | 为政企 AI 智能体项目生成多种报价模板和费用评估 |
+| [amoyalpha-presales-assistant](./amoyalpha-presales-assistant/) | 准备客户背调、拜访材料、方案生成、Ghost Deck、异议处理和会后跟进 |
+| [baidu-ecosystem-ai-product-review](./baidu-ecosystem-ai-product-review/) | 审核百度生态 AI 产品应用说明及配套截图、代码和调用量材料 |
+| [bp-arch-advisor](./bp-arch-advisor/) | 分析 BP 技术架构，并生成文心大模型增强方案 |
+| [frontend-diagram-system](./frontend-diagram-system/) | 把技术内容做成高质量架构图、方案图、交互解释页和可导出视觉资产 |
+| [llm-solution-techdoc-latex](./llm-solution-techdoc-latex/) | 生成客户交付型企业大模型技术方案 PDF |
+| [meeting-brief-generator](./meeting-brief-generator/) | 生成高层会谈背景、合作主线、谈话要点、建议提问和风险提示 |
+| [wenxin-partner-case-writer](./wenxin-partner-case-writer/) | 将 B 端客户或伙伴素材写成文心大模型官方伙伴案例推文 |
+
+### 数据、文档与评测处理
+
+| Skill | 适合做什么 |
+|---|---|
+| [aistudio-project-reviewer](./aistudio-project-reviewer/) | 对 AI Studio 项目进行评审、打分和改进建议输出 |
+| [batch-paper-pdf-to-markdown](./batch-paper-pdf-to-markdown/) | 批量将本地论文 PDF 转为 Markdown 和同名图片目录 |
+| [benchmark-model-test](./benchmark-model-test/) | 批量测试多个大模型对同一组 prompt 的响应并导出对比结果 |
+| [bilingual-video-note-enhancer](./bilingual-video-note-enhancer/) | 把英文 Obsidian 视频或转录笔记增强成紧凑中英双语学习笔记 |
+| [data-resource-evaluation](./data-resource-evaluation/) | 提交、记录和跟进数据资源评估流程 |
+| [expert-collection-analysis](./expert-collection-analysis/) | 采集政府、智库、媒体专家言论并进行 AI 分析和优先级评分 |
+| [expert-ops-strategy-pipeline](./expert-ops-strategy-pipeline/) | 构建专家运营内容采集、标注、评分和策略合成流水线 |
+| [feishu-expert-monitor](./feishu-expert-monitor/) | 维护飞书多维表格中的专家言论监控和结构化记录流程 |
+
+### 技术支持、平台与部署
+
+| Skill | 适合做什么 |
+|---|---|
+| [cloud-instance-ops](./cloud-instance-ops/) | 处理云服务器访问诊断、SSH/CLI 操作、服务检查和日志排障 |
+| [paddleocr-expert](./paddleocr-expert/) | 解答 PaddleOCR、PaddleX、PP-OCR、PP-Structure、PaddleOCR-VL 的选型、部署和排障问题 |
+| [paddleocr-ondevice-integration-navigator](./paddleocr-ondevice-integration-navigator/) | 判断 PaddleOCR 在移动端、嵌入式、浏览器或跨端框架中的端侧集成路径 |
+
+### Agent 方法论、流程治理与交接
+
+| Skill | 适合做什么 |
+|---|---|
+| [agent-boundary-design](./agent-boundary-design/) | 设计业务智能体职责边界、人工确认点和拒绝执行范围 |
+| [project-handover](./project-handover/) | 做项目或岗位交接，把隐性知识沉淀为交接手册、记忆文件和覆盖度报告 |
+| [scene-analysis](./scene-analysis/) | 在 AI 项目启动前判断需求应走 Agent、Workflow、DL、规则代码还是暂缓推进 |
+
+### 内容创作、社媒与活动运营
+
+| Skill | 适合做什么 |
+|---|---|
+| [ai-event-planner](./ai-event-planner/) | 策划 AI 技术活动主题、嘉宾画像、议程和宣传文案 |
+| [drama-agent](./drama-agent/) | 创作短剧剧本，覆盖选题、人物设定、情节规划和质量检查 |
+| [ip-drama-video-sop](./ip-drama-video-sop/) | 做 IP 小说改编短剧，从拆书、剧本、分镜到 AI 短视频生成 |
+| [micro-fiction-writer](./micro-fiction-writer/) | 把碎片化情绪或场景转化为 300-500 字微小说 |
+| [paddle-twitter-content-ops](./paddle-twitter-content-ops/) | 从中文素材生成 PaddlePaddle 英文 Twitter 内容 |
+| [partner-outreach-writer](./partner-outreach-writer/) | 撰写合作邀约、开发信、联名活动提案和合作跟进邮件 |
+| [social-media-content-planning](./social-media-content-planning/) | 为开发者社交账号生成选题、草稿和审稿内容 |
+| [wecom-group-invite](./wecom-group-invite/) | 按企业微信群入口令返回对应技术交流群邀请链接和标准回复 |
+| [worldcup2026-parallel-universe](./worldcup2026-parallel-universe/) | 把 2026 世界杯或足球比赛事实转化为平行宇宙微小说叙事 |
+
+### 图像、多模态与视觉产出
+
+| Skill | 适合做什么 |
+|---|---|
+| [ernie-image-assistant](./ernie-image-assistant/) | 从图片反推文生图 prompt、分析图片风格并生成复现提示词 |
+| [ernie-image-gen](./ernie-image-gen/) | 通过可配置 ERNIE Image 服务端点生成中文优先、多语言文字渲染图片 |
+| [scipop-comic-xinghe](./scipop-comic-xinghe/) | 把科普文章或科学内容转化为基于星河 API 的科普连环画 |
+| [xinghe-image](./xinghe-image/) | 生成信息图、文章配图、封面图、小红书图文等星河平台视觉内容 |
+
+## 目录结构与编写要求
+
+正式 Skill 推荐按如下结构组织：
 
 ```text
 skills/<skill-slug>/
 ├── SKILL.md
 ├── references/
-└── assets/
+├── assets/
+└── scripts/
 ```
 
-## 编写要求
+编写要求：
 
-- `SKILL.md` 为必需文件
-- `references/` 用于存放引用资料、样例和补充说明
-- `assets/` 用于存放图片、附件或其他资源
-- Skill 内容应围绕具体业务任务编写
-
-如不确定怎么写，请先参考 `skills/_template/`。
+- `skill-slug` 使用 `kebab-case`，并优先体现业务场景。
+- `SKILL.md` 为必需文件，应说明触发场景、输入要求、执行流程和输出形态。
+- `references/` 用于存放引用资料、样例、模板和补充说明。
+- `assets/` 用于存放图片、附件或其他静态资源。
+- `scripts/` 用于存放可复用脚本；脚本应避免依赖作者本机私有路径。
+- 新增 Skill 时请先参考 [`_template/`](./_template/)。


### PR DESCRIPTION
## 变更信息

- PR 类型: 仓库维护提交到 dev
- 目标分支: dev
- 源分支: docs/update-skills-readme-catalog
- 涉及 Skill 列表: 
- Skill 名称: 
- Skill 路径: 
- 业务场景: 
- 分支名: docs/update-skills-readme-catalog
- 本次是否由 Agent 辅助提交: 

## 本次变更内容

- 重写 skills/README.md 为按业务场景分类的 Skills 导航。
- 将 53 个已合入正式 Skill 整理进 8 个分类表格。
- 保留目录结构与新增 Skill 编写要求。

## 验证方式

- git diff --check
- 验证 53 个正式 Skill 目录均已在 README 中链接
- 验证 README 包含 8 个分类表格

## 补充说明

- 本 PR 只修改 skills/README.md。
- 本地未跟踪的 outputs/ 不属于本 PR。

## Agent 提交备注

- 仓库维护 PR，目标分支为 dev。